### PR TITLE
Sample assembly and modules

### DIFF
--- a/examples/adoc-samples/demo-assembly.adoc
+++ b/examples/adoc-samples/demo-assembly.adoc
@@ -26,6 +26,9 @@ include::modules/installation-creating-aws-control-plane.adoc[leveloffset=+1]
 //This one includes an external file as a code sample.
 include::modules/installation-cloudformation-security.adoc[leveloffset=+1]
 
+//This one includes an [source,terminal,subs="+quotes"] example.
+include::modules/virt-accessing-vm-yaml-ssh.adoc[leveloffset=+1]
+
 //This one has some footnotes. Note that this module has a different way of controlling the conditional content, so we have to set an unset a variable in the assembly.
 :virt-importing-vmware-vm:
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]

--- a/examples/adoc-samples/demo-assembly.adoc
+++ b/examples/adoc-samples/demo-assembly.adoc
@@ -23,6 +23,8 @@ include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
 //This one has another list in the callouts.
 include::modules/installation-creating-aws-control-plane.adoc[leveloffset=+1]
 
+//This one includes an external file as a code sample.
+include::modules/installation-cloudformation-security.adoc[leveloffset=+1]
 
 //This one has some footnotes. Note that this module has a different way of controlling the conditional content, so we have to set an unset a variable in the assembly.
 :virt-importing-vmware-vm:

--- a/examples/adoc-samples/demo-assembly.adoc
+++ b/examples/adoc-samples/demo-assembly.adoc
@@ -1,0 +1,36 @@
+[id="demo-assembly"]
+= Demo assembly of complicated modules
+include::modules/common-attributes.adoc[]
+include::modules/virt-document-attributes.adoc[]
+:context: demo-assembly
+
+toc::[]
+
+This is a demo assembly of some modules from the `openshift/openshift-docs` repo that have complex elements.
+
+//This one has a list in the callouts.
+include::modules/templates-writing-description.adoc[leveloffset=+1]
+
+//This one has some complicated if/ifeval statements and notes in callouts but should display the default values.
+include::modules/installation-aws-config-yaml.adoc[leveloffset=+1]
+
+//This one has YAML samples in notes.
+include::modules/templates-writing-parameters.adoc[leveloffset=+1]
+
+//This one has discrete headings.
+include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
+
+//This one has another list in the callouts.
+include::modules/installation-creating-aws-control-plane.adoc[leveloffset=+1]
+
+
+//This one has some footnotes. Note that this module has a different way of controlling the conditional content, so we have to set an unset a variable in the assembly.
+:virt-importing-vmware-vm:
+include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
+:!virt-importing-vmware-vm:
+
+//This one has some really bad tables and complicated conditional statements. I added a pair of ifeval statements to the modules so that the AWS values are displayed.
+include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
+
+//This one has a really short definition list in step 2.
+include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]

--- a/examples/adoc-samples/modules/cluster-autoscaler-operator.adoc
+++ b/examples/adoc-samples/modules/cluster-autoscaler-operator.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="cluster-autoscaler-operator_{context}"]
+= Cluster Autoscaler Operator
+
+[discrete]
+== Purpose
+
+The Cluster Autoscaler Operator manages deployments of the OpenShift Cluster Autoscaler using the `cluster-api` provider.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/cluster-autoscaler-operator[cluster-autoscaler-operator]
+
+[discrete]
+== CRDs
+
+* `ClusterAutoscaler`: This is a singleton resource, which controls the configuration autoscaler instance for the cluster. The Operator only responds to the `ClusterAutoscaler` resource named `default` in the managed namespace, the value of the `WATCH_NAMESPACE` environment variable.
+* `MachineAutoscaler`: This resource targets a node group and manages the annotations to enable and configure autoscaling for that group, the `min` and `max` size. Currently only `MachineSet` objects can be targeted.

--- a/examples/adoc-samples/modules/common-attributes.adoc
+++ b/examples/adoc-samples/modules/common-attributes.adoc
@@ -1,0 +1,44 @@
+// The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.8".
+// {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
+// See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#product-name-version for more information on this topic.
+// Other common attributes are defined in the following lines:
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:imagesdir: images
+:prewrap!:
+:op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
+:op-system: RHCOS
+:op-system-base: RHEL
+:op-system-base-full: Red Hat Enterprise Linux (RHEL)
+ifdef::openshift-origin[]
+:op-system-first: Fedora CoreOS (FCOS)
+:op-system: FCOS
+:op-system-base: Fedora
+:op-system-base-full: Fedora
+endif::[]
+:tsb-name: Template Service Broker
+:kebab: image:kebab.png[title="Options menu"]
+:rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
+:rh-openstack: RHOSP
+:cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:rh-storage-first: Red Hat OpenShift Container Storage
+:rh-storage: OpenShift Container Storage
+:rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
+:rh-rhacm: RHACM
+:sandboxed-containers-first: OpenShift sandboxed containers
+:sandboxed-containers-operator: OpenShift sandboxed containers Operator
+:rh-virtualization-first: Red Hat Virtualization (RHV)
+:rh-virtualization: RHV
+:rh-virtualization-engine-name: Manager
+ifdef::openshift-origin[]
+:rh-virtualization-first: oVirt
+:rh-virtualization: oVirt
+:rh-virtualization-engine-name: Engine
+endif::[]
+:launch: image:app-launcher.png[title="Application Launcher"]
+:mtc-short: MTC
+:mtc-full: Migration Toolkit for Containers
+:mtc-version: 1.5

--- a/examples/adoc-samples/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/examples/adoc-samples/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_azure/installing-azure-network-customizations.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+
+[id="configuring-hybrid-ovnkubernetes_{context}"]
+= Configuring hybrid networking with OVN-Kubernetes
+
+You can configure your cluster to use hybrid networking with OVN-Kubernetes. This allows a hybrid cluster that supports different node networking configurations. For example, this is necessary to run both Linux and Windows nodes in a cluster.
+
+[IMPORTANT]
+====
+You must configure hybrid networking with OVN-Kubernetes during the installation of your cluster. You cannot switch to hybrid networking after the installation process.
+====
+
+.Prerequisites
+
+* You defined `OVNKubernetes` for the `networking.networkType` parameter in the `install-config.yaml` file. See the installation documentation for configuring {product-title} network customizations on your chosen cloud provider for more information.
+
+.Procedure
+
+. Change to the directory that contains the installation program and create the manifests:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir=<installation_directory>
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+--
+
+. Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
++
+[source,terminal]
+----
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+EOF
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the directory name that contains the
+`manifests/` directory for your cluster.
+--
+
+. Open the `cluster-network-03-config.yml` file in an editor and configure OVN-Kubernetes with hybrid networking, such as in the following example:
++
+--
+.Specify a hybrid networking configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      hybridOverlayConfig:
+        hybridClusterNetwork: <1>
+        - cidr: 10.132.0.0/14
+          hostPrefix: 23
+        hybridOverlayVXLANPort: 9898 <2>
+----
+<1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR.
+<2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
+--
++
+[NOTE]
+====
+Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 is not supported on clusters with a custom `hybridOverlayVXLANPort` value because this Windows server version does not support selecting a custom VXLAN port.
+====
+
+. Save the `cluster-network-03-config.yml` file and quit the text editor.
+. Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
+installation program deletes the `manifests/` directory when creating the
+cluster.

--- a/examples/adoc-samples/modules/installation-aws-config-yaml.adoc
+++ b/examples/adoc-samples/modules/installation-aws-config-yaml.adoc
@@ -1,0 +1,398 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-customizations.adoc
+// * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-vpc.adoc
+// * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:with-networking:
+endif::[]
+ifeval::["{context}" != "installing-aws-network-customizations"]
+:without-networking:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:vpc:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:vpc:
+:private:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:vpc:
+:private:
+:gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-china-region"]
+:vpc:
+:private:
+:china:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:restricted:
+endif::[]
+
+[id="installation-aws-config-yaml_{context}"]
+= Sample customized `install-config.yaml` file for AWS
+
+You can customize the installation configuration file (`install-config.yaml`) to specify more details about
+your {product-title} cluster's platform or modify the values of the required
+parameters.
+
+ifndef::china,gov[]
+[IMPORTANT]
+====
+This sample YAML file is provided for reference only. You must obtain your
+`install-config.yaml` file by using the installation program and modify it.
+====
+endif::china,gov[]
+
+ifdef::china,gov[]
+[IMPORTANT]
+====
+This sample YAML file is provided for reference only. Use it as a resource to enter parameter values into the installation configuration file that you created manually.
+====
+endif::china,gov[]
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com <1>
+credentialsMode: Mint <2>
+controlPlane: <3> <4>
+  hyperthreading: Enabled <5>
+  name: master
+  platform:
+    aws:
+      zones:
+ifdef::china[]
+      - cn-north-1a
+      - cn-north-1b
+endif::china[]
+ifdef::gov[]
+      - us-gov-west-1a
+      - us-gov-west-1b
+endif::gov[]
+ifndef::gov,china[]
+      - us-west-2a
+      - us-west-2b
+endif::gov,china[]
+      rootVolume:
+        iops: 4000
+        size: 500
+        type: io1 <6>
+      type: m5.xlarge
+  replicas: 3
+compute: <3>
+- hyperthreading: Enabled <5>
+  name: worker
+  platform:
+    aws:
+      rootVolume:
+        iops: 2000
+        size: 500
+        type: io1 <6>
+      type: c5.4xlarge
+      zones:
+ifdef::china[]
+      - cn-north-1a
+endif::china[]
+ifdef::gov[]
+      - us-gov-west-1c
+endif::gov[]
+ifndef::gov,china[]
+      - us-west-2c
+endif::gov,china[]
+  replicas: 3
+metadata:
+  name: test-cluster <1>
+ifdef::without-networking[]
+networking:
+endif::[]
+ifdef::with-networking[]
+networking: <3>
+endif::[]
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
+  networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  aws:
+ifndef::gov,china[]
+    region: us-west-2 <1>
+endif::gov,china[]
+ifdef::china[]
+    region: cn-north-1 <1>
+endif::china[]
+ifdef::gov[]
+    region: us-gov-west-1 <1>
+endif::gov[]
+    userTags:
+      adminContact: jdoe
+      costCenter: 7536
+ifdef::vpc,restricted[]
+    subnets: <7>
+    - subnet-1
+    - subnet-2
+    - subnet-3
+ifndef::gov,china[]
+    amiID: ami-96c6f8f7 <8>
+endif::gov,china[]
+ifdef::gov,china[]
+    amiID: ami-96c6f8f7 <1> <8>
+endif::gov,china[]
+    serviceEndpoints: <9>
+      - name: ec2
+ifndef::china[]
+        url: https://vpce-id.ec2.us-west-2.vpce.amazonaws.com
+endif::china[]
+ifdef::china[]
+        url: https://vpce-id.ec2.cn-north-1.vpce.amazonaws.com.cn
+endif::china[]
+    hostedZone: Z3URY6TWQ91KVV <10>
+endif::vpc,restricted[]
+ifndef::vpc,restricted[]
+    amiID: ami-96c6f8f7 <7>
+    serviceEndpoints: <8>
+      - name: ec2
+        url: https://vpce-id.ec2.us-west-2.vpce.amazonaws.com
+endif::vpc,restricted[]
+ifdef::vpc,restricted[]
+ifndef::openshift-origin[]
+fips: false <11>
+sshKey: ssh-ed25519 AAAA... <12>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <11>
+endif::openshift-origin[]
+endif::vpc,restricted[]
+ifndef::vpc,restricted[]
+ifndef::openshift-origin[]
+fips: false <9>
+sshKey: ssh-ed25519 AAAA... <10>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <9>
+endif::openshift-origin[]
+endif::vpc,restricted[]
+ifdef::private[]
+ifndef::openshift-origin[]
+publish: Internal <13>
+endif::openshift-origin[]
+endif::private[]
+ifndef::restricted[]
+pullSecret: '{"auths": ...}' <1>
+endif::restricted[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
+endif::openshift-origin[]
+endif::restricted[]
+ifdef::gov[]
+ifndef::openshift-origin[]
+additionalTrustBundle: | <14>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+endif::openshift-origin[]
+endif::gov[]
+ifdef::private[]
+ifdef::openshift-origin[]
+publish: Internal <12>
+endif::openshift-origin[]
+endif::private[]
+ifdef::gov[]
+ifdef::openshift-origin[]
+additionalTrustBundle: | <13>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+endif::openshift-origin[]
+endif::gov[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+additionalTrustBundle: | <14>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+imageContentSources: <15>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+additionalTrustBundle: | <13>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+imageContentSources: <14>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
+endif::restricted[]
+
+
+----
+ifndef::gov,china[]
+<1> Required. The installation program prompts you for this value.
+endif::gov,china[]
+ifdef::gov,china[]
+<1> Required.
+endif::gov,china[]
+<2> Optional: Add this parameter to force the Cloud Credential Operator (CCO) to use the specified mode, instead of having the CCO dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the _Cloud Credential Operator_ entry in the _Red Hat Operators reference_ content.
+<3> If you do not provide these parameters and values, the installation program
+provides the default value.
+<4> The `controlPlane` section is a single mapping, but the compute section is a
+sequence of mappings. To meet the requirements of the different data structures,
+the first line of the `compute` section must begin with a hyphen, `-`, and the
+first line of the `controlPlane` section must not. Although both sections
+currently define a single machine pool, it is possible that future versions
+of {product-title} will support defining multiple compute pools during
+installation. Only one control plane pool is used.
+<5> Whether to enable or disable simultaneous multithreading, or
+`hyperthreading`. By default, simultaneous multithreading is enabled
+to increase the performance of your machines' cores. You can disable it by
+setting the parameter value to `Disabled`. If you disable simultaneous
+multithreading in some cluster machines, you must disable it in all cluster
+machines.
++
+[IMPORTANT]
+====
+If you disable simultaneous multithreading, ensure that your capacity planning
+accounts for the dramatically decreased machine performance. Use larger
+instance types, such as `m4.2xlarge` or `m5.2xlarge`, for your machines if you
+disable simultaneous multithreading.
+====
+<6> To configure faster storage for etcd, especially for larger clusters, set the
+storage type as `io1` and set `iops` to `2000`.
+ifdef::vpc,restricted[]
+<7> If you provide your own VPC, specify subnets for each availability zone that your cluster uses.
+<8> The ID of the AMI used to boot machines for the cluster. If set, the AMI
+must belong to the same region as the cluster.
+<9> The AWS service endpoints. Custom endpoints are required when installing to
+an unknown AWS region. The endpoint URL must use the `https` protocol and the
+host must trust the certificate.
+<10> The ID of your existing Route 53 private hosted zone. Providing an existing hosted zone requires that you supply your own VPC and the hosted zone is already associated with the VPC prior to installing your cluster. If undefined, the installation program creates a new hosted zone.
+ifndef::openshift-origin[]
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<12> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<11> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+endif::vpc,restricted[]
+ifndef::vpc,restricted[]
+<7> The ID of the AMI used to boot machines for the cluster. If set, the AMI
+must belong to the same region as the cluster.
+<8> The AWS service endpoints. Custom endpoints are required when installing to
+an unknown AWS region. The endpoint URL must use the `https` protocol and the
+host must trust the certificate.
+ifndef::openshift-origin[]
+<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<10> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<9> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+endif::vpc,restricted[]
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+ifdef::private[]
+ifndef::openshift-origin[]
+<13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+endif::openshift-origin[]
+endif::private[]
+ifdef::gov[]
+ifndef::openshift-origin[]
+<14> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<13> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+endif::openshift-origin[]
+endif::gov[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+<13> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<14> Provide the contents of the certificate file that you used for your mirror registry.
+<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<12> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
+endif::restricted[]
+
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!with-networking:
+endif::[]
+ifeval::["{context}" != "installing-aws-network-customizations"]
+:!without-networking:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:!vpc:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!vpc:
+:!private:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!vpc:
+:!private:
+:!gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-china-region"]
+:!vpc:
+:!private:
+:!china:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:!restricted:
+endif::[]

--- a/examples/adoc-samples/modules/installation-cloudformation-security.adoc
+++ b/examples/adoc-samples/modules/installation-cloudformation-security.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-user-infra.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+
+[id="installation-cloudformation-security_{context}"]
+= CloudFormation template for security objects
+
+You can use the following CloudFormation template to deploy the security objects
+that you need for your {product-title} cluster.
+
+.CloudFormation template for security objects
+[%collapsible]
+====
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/03_cluster_security.yaml[]
+----
+====

--- a/examples/adoc-samples/modules/installation-configuration-parameters.adoc
+++ b/examples/adoc-samples/modules/installation-configuration-parameters.adoc
@@ -1,0 +1,1355 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-customizations.adoc
+// * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-vpc.adoc
+// * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+// * installing/installing_azure/installing-azure-customizations.adoc
+// * installing/installing_azure/installing-azure-government-region.adoc
+// * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_azure/installing-azure-private.adoc
+// * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// * installing/installing_openstack/installing-openstack-installer-custom.adoc
+// * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+// * installing/installing_openstack/installing-openstack-user.adoc
+// * installing/installing_openstack/installing-openstack-user-kuryr.adoc
+// * installing/installing_rhv/installing-rhv-customizations.adoc
+// * installing/installing_vmc/installing-vmc-customizations.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+
+ifeval::["{context}" == "demo-assembly"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-customizations"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:gcp:
+endif::[]
+// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
+ifeval::["{context}" == "installing-bare-metal"]
+:bare:
+endif::[]
+// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
+ifeval::["{context}" == "installing-bare-metal-network-customizations"]
+:bare:
+endif::[]
+// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:bare:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-custom"]
+:osp:
+:osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:osp:
+:osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user"]
+:osp:
+:osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-kuryr"]
+:osp:
+:osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-sr-iov"]
+:osp:
+:osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
+:osp:
+:osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-rhv-customizations"]
+:rhv:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
+:osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:ibm-power:
+endif::[]
+
+[id="installation-configuration-parameters_{context}"]
+= Installation configuration parameters
+
+// If install-config.yaml is generated by openshift-install
+ifndef::bare,ibm-power,ibm-z[]
+Before you deploy an {product-title} cluster, you provide parameter values to describe your account on the cloud platform that hosts your cluster and optionally customize your cluster's platform. When you create the `install-config.yaml` installation configuration file, you provide values for the required parameters through the command line. If you customize your cluster, you can modify the `install-config.yaml` file to provide more details about the platform.
+endif::bare,ibm-power,ibm-z[]
+// If the user manually creates install-config.yaml
+ifdef::bare,ibm-power,ibm-z[]
+Before you deploy an {product-title} cluster, you provide a customized `install-config.yaml` installation configuration file that describes the details for your environment.
+endif::bare,ibm-power,ibm-z[]
+
+[NOTE]
+====
+After installation, you cannot modify these parameters in the `install-config.yaml` file.
+====
+
+[IMPORTANT]
+====
+The `openshift-install` command does not validate field names for parameters. If an incorrect name is specified, the related file or object is not created, and no error is reported. Ensure that the field names for any parameters that are specified are correct.
+====
+
+[id="installation-configuration-parameters-required_{context}"]
+== Required configuration parameters
+
+Required installation configuration parameters are described in the following table:
+
+.Required parameters
+[cols=".^2,.^3,.^5a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`apiVersion`
+|The API version for the `install-config.yaml` content. The current version is `v1`. The installer may also support older API versions.
+|String
+
+|`baseDomain`
+|The base domain of your cloud provider. The base domain is used to create routes to your {product-title} cluster components. The full DNS name for your cluster is a combination of the `baseDomain` and `metadata.name` parameter values that uses the `<metadata.name>.<baseDomain>` format.
+|A fully-qualified domain or subdomain name, such as `example.com`.
+
+|`metadata`
+|Kubernetes resource `ObjectMeta`, from which only the `name` parameter is consumed.
+|Object
+
+|`metadata.name`
+|The name of the cluster. DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
+|String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
+ifdef::osp[]
+The string must be 14 characters or fewer long.
+endif::osp[]
+
+|`platform`
+|The configuration for the specific platform upon which to perform the installation: `aws`, `baremetal`, `azure`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
+|Object
+
+ifndef::openshift-origin[]
+|`pullSecret`
+|Get a pull secret from link:https://console.redhat.com/openshift/install/pull-secret[] to authenticate downloading container images for {product-title} components from services such as Quay.io.
+|
+[source,json]
+----
+{
+   "auths":{
+      "cloud.openshift.com":{
+         "auth":"b3Blb=",
+         "email":"you@example.com"
+      },
+      "quay.io":{
+         "auth":"b3Blb=",
+         "email":"you@example.com"
+      }
+   }
+}
+----
+endif::[]
+
+|====
+
+[id="installation-configuration-parameters-network_{context}"]
+== Network configuration parameters
+
+You can customize your installation configuration based on the requirements of your existing network infrastructure. For example, you can expand the IP address block for the cluster network or provide different IP address blocks than the defaults.
+
+ifndef::bare[]
+Only IPv4 addresses are supported.
+endif::bare[]
+ifdef::bare[]
+If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
+
+If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
+
+If you configure your cluster to use both IP address families, you must specify IPv4 and IPv6 addresses in the same order for all network configuration parameters. For example, in the following configuration IPv4 addresses are listed before IPv6 addresses.
+
+[source,yaml]
+----
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  - cidr: fd00:10:128::/56
+    hostPrefix: 64
+  serviceNetwork:
+  - 172.30.0.0/16
+  - fd00:172:16::/112
+----
+endif::bare[]
+
+.Network parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`networking`
+|The configuration for the cluster network.
+|Object
+
+[NOTE]
+====
+You cannot modify parameters specified by the `networking` object after installation.
+====
+
+|`networking.networkType`
+|The cluster network provider Container Network Interface (CNI) plug-in to install.
+|
+ifdef::openshift-origin[]
+Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
+endif::openshift-origin[]
+ifndef::openshift-origin[]
+Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OpenShiftSDN`.
+endif::openshift-origin[]
+
+|`networking.clusterNetwork`
+|
+The IP address blocks for pods.
+
+The default value is `10.128.0.0/14` with a host prefix of `/23`.
+
+If you specify multiple IP address blocks, the blocks must not overlap.
+|An array of objects. For example:
+
+[source,yaml]
+----
+ifndef::bare[]
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+endif::bare[]
+ifdef::bare[]
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  - cidr: fd01::/48
+    hostPrefix: 64
+endif::bare[]
+----
+
+|`networking.clusterNetwork.cidr`
+|
+Required if you use `networking.clusterNetwork`. An IP address block.
+
+ifndef::bare[]
+An IPv4 network.
+endif::bare[]
+ifdef::bare[]
+If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
+endif::bare[]
+|
+An IP address block in Classless Inter-Domain Routing (CIDR) notation.
+The prefix length for an IPv4 block is between `0` and `32`.
+ifdef::bare[]
+The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
+endif::bare[]
+
+|`networking.clusterNetwork.hostPrefix`
+|The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23` then each node is assigned a `/23` subnet out of the given `cidr`. A `hostPrefix` value of `23` provides 510 (2^(32 - 23) - 2) pod IP addresses.
+|
+A subnet prefix.
+
+ifndef::bare[]
+The default value is `23`.
+endif::bare[]
+ifdef::bare[]
+For an IPv4 network the default value is `23`.
+For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
+endif::bare[]
+
+|`networking.serviceNetwork`
+|
+The IP address block for services. The default value is `172.30.0.0/16`.
+
+The OpenShift SDN and OVN-Kubernetes network providers support only a single IP address block for the service network.
+
+ifdef::bare[]
+If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
+endif::bare[]
+
+|
+An array with an IP address block in CIDR format. For example:
+
+[source,yaml]
+----
+ifndef::bare[]
+networking:
+  serviceNetwork:
+   - 172.30.0.0/16
+endif::bare[]
+ifdef::bare[]
+networking:
+  serviceNetwork:
+   - 172.30.0.0/16
+   - fd02::/112
+endif::bare[]
+----
+
+|`networking.machineNetwork`
+|
+The IP address blocks for machines.
+
+If you specify multiple IP address blocks, the blocks must not overlap.
+
+ifdef::ibm-z,ibm-power[]
+If you specify multiple IP kernel arguments, the `machineNetwork.cidr` value must be the CIDR of the primary network.
+endif::ibm-z,ibm-power[]
+|An array of objects. For example:
+
+[source,yaml]
+----
+networking:
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+----
+
+|`networking.machineNetwork.cidr`
+|
+Required if you use `networking.machineNetwork`. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default value is `192.168.126.0/24`.
+|
+An IP network block in CIDR notation.
+
+ifndef::bare[]
+For example, `10.0.0.0/16`.
+endif::bare[]
+ifdef::bare[]
+For example, `10.0.0.0/16` or `fd00::/48`.
+endif::bare[]
+
+[NOTE]
+====
+Set the `networking.machineNetwork` to match the CIDR that the preferred NIC resides in.
+====
+
+|====
+
+[id="installation-configuration-parameters-optional_{context}"]
+== Optional configuration parameters
+
+Optional installation configuration parameters are described in the following table:
+
+.Optional parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`additionalTrustBundle`
+|A PEM-encoded X.509 certificate bundle that is added to the nodes' trusted certificate store. This trust bundle may also be used when a proxy has been configured.
+|String
+
+|`compute`
+|The configuration for the machines that comprise the compute nodes.
+|Array of `MachinePool` objects. For details, see the following "Machine-pool" table.
+
+ifndef::ibm-z,ibm-power[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `amd64` (the default).
+|String
+endif::ibm-z,ibm-power[]
+
+ifdef::ibm-z[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `s390x` (the default).
+|String
+endif::ibm-z[]
+
+ifdef::ibm-power[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
+|String
+endif::ibm-power[]
+
+|`compute.hyperthreading`
+|Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
+[IMPORTANT]
+====
+If you disable simultaneous multithreading, ensure that your capacity planning
+accounts for the dramatically decreased machine performance.
+====
+|`Enabled` or `Disabled`
+
+|`compute.name`
+|Required if you use `compute`. The name of the machine pool.
+|`worker`
+
+|`compute.platform`
+|Required if you use `compute`. Use this parameter to specify the cloud provider to host the worker machines. This parameter value must match the `controlPlane.platform` parameter value.
+|`aws`, `azure`, `gcp`, `openstack`, `ovirt`, `vsphere`, or `{}`
+
+|`compute.replicas`
+|The number of compute machines, which are also known as worker machines, to provision.
+|A positive integer greater than or equal to `2`. The default value is `3`.
+
+|`controlPlane`
+|The configuration for the machines that comprise the control plane.
+|Array of `MachinePool` objects. For details, see the following "Machine-pool" table.
+
+ifndef::ibm-z,ibm-power[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `amd64` (the default).
+|String
+endif::ibm-z,ibm-power[]
+
+ifdef::ibm-z[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `s390x` (the default).
+|String
+endif::ibm-z[]
+
+ifdef::ibm-power[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
+|String
+endif::ibm-power[]
+
+|`controlPlane.hyperthreading`
+|Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
+[IMPORTANT]
+====
+If you disable simultaneous multithreading, ensure that your capacity planning
+accounts for the dramatically decreased machine performance.
+====
+|`Enabled` or `Disabled`
+
+|`controlPlane.name`
+|Required if you use `controlPlane`. The name of the machine pool.
+|`master`
+
+|`controlPlane.platform`
+|Required if you use `controlPlane`. Use this parameter to specify the cloud provider that hosts the control plane machines. This parameter value must match the `compute.platform` parameter value.
+|`aws`, `azure`, `gcp`, `openstack`, `ovirt`, `vsphere`, or `{}`
+
+|`controlPlane.replicas`
+|The number of control plane machines to provision.
+|The only supported value is `3`, which is the default value.
+
+|`credentialsMode`
+|The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
+[NOTE]
+====
+Not all CCO modes are supported for all cloud providers. For more information on CCO modes, see the _Cloud Credential Operator_ entry in the _Red Hat Operators reference_ content.
+====
+|`Mint`, `Passthrough`, `Manual`, or an empty string (`""`).
+ifndef::openshift-origin[]
+|`fips`
+|Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+[NOTE]
+====
+If you are using Azure File storage, you cannot enable FIPS mode.
+====
+|`false` or `true`
+endif::openshift-origin[]
+|`imageContentSources`
+|Sources and repositories for the release-image content.
+|Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
+
+|`imageContentSources.source`
+|Required if you use `imageContentSources`. Specify the repository that users refer to, for example, in image pull specifications.
+|String
+
+|`imageContentSources.mirrors`
+|Specify one or more repositories that may also contain the same images.
+|Array of strings
+
+|`publish`
+|How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
+|
+ifdef::aws,azure,gcp[]
+`Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
+endif::[]
+ifndef::aws,azure,gcp[]
+`Internal` or `External`. The default value is `External`.
+
+Setting this field to `Internal` is not supported on non-cloud platforms.
+ifeval::[{product-version} <= 4.7]
+[IMPORTANT]
+====
+If the value of the field is set to `Internal`, the cluster will become non-functional. For more information, refer to link:https://bugzilla.redhat.com/show_bug.cgi?id=1953035[BZ#1953035].
+====
+endif::[]
+endif::[]
+
+|`sshKey`
+| The SSH key to authenticate access to your cluster machines.
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+a|For example, `sshKey: ssh-ed25519 AAAA..`.
+
+|====
+
+ifdef::aws[]
+[id="installation-configuration-parameters-optional-aws_{context}"]
+== Optional AWS configuration parameters
+
+Optional AWS configuration parameters are described in the following table:
+
+.Optional AWS parameters
+[cols=".^2,.^3,.^5a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`compute.platform.aws.amiID`
+|The AWS AMI used to boot compute machines for the cluster. This is required for regions that require a custom {op-system} AMI.
+|Any published or custom {op-system} AMI that belongs to the set AWS region.
+
+|`compute.platform.aws.iamRole`
+|A pre-existing AWS IAM role applied to the compute machine pool instance profiles. You can use these fields to match naming schemes and include predefined permissions boundaries for your IAM roles. If undefined, the installation program creates a new IAM role.
+|The name of a valid AWS IAM role.
+
+|`compute.platform.aws.rootVolume.iops`
+|The Input/Output Operations Per Second (IOPS) that is reserved for the root volume.
+|Integer, for example `4000`.
+
+|`compute.platform.aws.rootVolume.size`
+|The size in GiB of the root volume.
+|Integer, for example `500`.
+
+|`compute.platform.aws.rootVolume.type`
+|The type of the root volume.
+|Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type],
+such as `io1`.
+
+|`compute.platform.aws.type`
+|The EC2 instance type for the compute machines.
+|Valid AWS instance type, such as `m4.2xlarge`. See the *Instance types for machines* table that follows.
+//add an xref when possible.
+
+|`compute.platform.aws.zones`
+|The availability zones where the installation program creates machines for the compute machine pool. If you provide your own VPC, you must provide a subnet in that availability zone.
+|A list of valid AWS availability zones, such as `us-east-1c`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
+|`compute.aws.region`
+|The AWS region that the installation program creates compute resources in.
+|Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
+
+|`controlPlane.platform.aws.amiID`
+|The AWS AMI used to boot control plane machines for the cluster.  This is required for regions that require a custom {op-system} AMI.
+|Any published or custom {op-system} AMI that belongs to the set AWS region.
+
+|`controlPlane.platform.aws.iamRole`
+|A pre-existing AWS IAM role applied to the control plane machine pool instance profiles. You can use these fields to match naming schemes and include predefined permissions boundaries for your IAM roles. If undefined, the installation program creates a new IAM role.
+|The name of a valid AWS IAM role.
+
+|`controlPlane.platform.aws.type`
+|The EC2 instance type for the control plane machines.
+|Valid AWS instance type, such as `m5.xlarge`. See the *Instance types for machines* table that follows.
+//add an xref when possible
+
+|`controlPlane.platform.aws.zones`
+|The availability zones where the installation program creates machines for the
+control plane machine pool.
+|A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
+|`controlPlane.aws.region`
+|The AWS region that the installation program creates control plane resources in.
+|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
+
+|`platform.aws.amiID`
+|The AWS AMI used to boot all machines for the cluster. If set, the AMI must
+belong to the same region as the cluster. This is required for regions that require a custom {op-system} AMI.
+|Any published or custom {op-system} AMI that belongs to the set AWS region.
+
+|`platform.aws.hostedZone`
+|An existing Route 53 private hosted zone for the cluster. You can only use a pre-existing hosted zone when also supplying your own VPC. The hosted zone must already be associated with the user-provided VPC before installation. Also, the domain of the hosted zone must be the cluster domain or a parent of the cluster domain. If undefined, the installation program creates a new hosted zone.
+|String, for example `Z3URY6TWQ91KVV`.
+
+|`platform.aws.serviceEndpoints.name`
+|The AWS service endpoint name. Custom endpoints are only required for cases
+where alternative AWS endpoints, like FIPS, must be used. Custom API endpoints
+can be specified for EC2, S3, IAM, Elastic Load Balancing, Tagging, Route 53,
+and STS AWS services.
+|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name.
+
+|`platform.aws.serviceEndpoints.url`
+|The AWS service endpoint URL. The URL must use the `https` protocol and the
+host must trust the certificate.
+|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] URL.
+
+|`platform.aws.userTags`
+|A map of keys and values that the installation program adds as tags to all resources that it creates.
+|Any valid YAML map, such as key value pairs in the `<key>: <value>` format. For more information about AWS tags, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Tagging Your Amazon EC2 Resources] in the AWS documentation.
+
+|`platform.aws.subnets`
+|If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify. For a standard cluster, specify a public and a private subnet for each availability zone. For a private cluster, specify a private subnet for each availability zone.
+|Valid subnet IDs.
+
+|====
+endif::aws[]
+
+ifdef::osp[]
+[id="installation-configuration-parameters-additional-osp_{context}"]
+== Additional {rh-openstack-first} configuration parameters
+
+Additional {rh-openstack} configuration parameters are described in the following table:
+
+.Additional {rh-openstack} parameters
+[cols=".^2m,.^3a,^5a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`compute.platform.openstack.rootVolume.size`
+|For compute machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
+|Integer, for example `30`.
+
+|`compute.platform.openstack.rootVolume.type`
+|For compute machines, the root volume's type.
+|String, for example `performance`.
+
+|`controlPlane.platform.openstack.rootVolume.size`
+|For control plane machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
+|Integer, for example `30`.
+
+|`controlPlane.platform.openstack.rootVolume.type`
+|For control plane machines, the root volume's type.
+|String, for example `performance`.
+
+|`platform.openstack.cloud`
+|The name of the {rh-openstack} cloud to use from the list of clouds in the
+`clouds.yaml` file.
+|String, for example `MyCloud`.
+
+|`platform.openstack.externalNetwork`
+|The {rh-openstack} external network name to be used for installation.
+|String, for example `external`.
+
+|`platform.openstack.computeFlavor`
+|The {rh-openstack} flavor to use for control plane and compute machines.
+
+This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually.
+
+|String, for example `m1.xlarge`.
+|====
+
+[id="installation-configuration-parameters-optional-osp_{context}"]
+== Optional {rh-openstack} configuration parameters
+
+Optional {rh-openstack} configuration parameters are described in the following table:
+
+.Optional {rh-openstack} parameters
+[%header, cols=".^2,.^3,.^5a"]
+|====
+|Parameter|Description|Values
+
+|`compute.platform.openstack.additionalNetworkIDs`
+|Additional networks that are associated with compute machines. Allowed address pairs are not created for additional networks.
+|A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+
+|`compute.platform.openstack.additionalSecurityGroupIDs`
+|Additional security groups that are associated with compute machines.
+|A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
+
+|`compute.platform.openstack.zones`
+|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+
+On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
+|A list of strings. For example, `["zone-1", "zone-2"]`.
+
+|`compute.platform.openstack.rootVolume.zones`
+|For compute machines, the availability zone to install root volumes on. If you do not set a value for this parameter, the installer selects the default availability zone.
+|A list of strings, for example `["zone-1", "zone-2"]`.
+
+|`controlPlane.platform.openstack.additionalNetworkIDs`
+|Additional networks that are associated with control plane machines. Allowed address pairs are not created for additional networks.
+|A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+
+|`controlPlane.platform.openstack.additionalSecurityGroupIDs`
+|Additional security groups that are associated with control plane machines.
+|A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
+
+|`controlPlane.platform.openstack.zones`
+|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+
+On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
+|A list of strings. For example, `["zone-1", "zone-2"]`.
+
+|`controlPlane.platform.openstack.rootVolume.zones`
+|For control plane machines,  the availability zone to install root volumes on. If you do not set this value, the installer selects the default availability zone.
+|A list of strings, for example `["zone-1", "zone-2"]`.
+
+|`platform.openstack.clusterOSImage`
+|The location from which the installer downloads the {op-system} image.
+
+You must set this parameter to perform an installation in a restricted network.
+|An HTTP or HTTPS URL, optionally with an SHA-256 checksum.
+
+For example, `\http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d`.
+The value can also be the name of an existing Glance image, for example `my-rhcos`.
+
+|`platform.openstack.clusterOSImageProperties`
+|Properties to add to the installer-uploaded ClusterOSImage in Glance. This property is ignored if `platform.openstack.clusterOSImage` is set to an existing Glance image.
+
+You can use this property to exceed the default persistent volume (PV) limit for {rh-openstack} of 26 PVs per node. To exceed the limit, set the `hw_scsi_model` property value to `virtio-scsi` and the `hw_disk_bus` value to  `scsi`.
+
+You can also use this property to enable the QEMU guest agent by including the `hw_qemu_guest_agent` property with a value of `yes`.
+|A list of key-value string pairs. For example, `["hw_scsi_model": "virtio-scsi", "hw_disk_bus": "scsi"]`.
+
+|`platform.openstack.defaultMachinePlatform`
+|The default machine pool platform configuration.
+|
+[source,json]
+----
+{
+   "type": "ml.large",
+   "rootVolume": {
+      "size": 30,
+      "type": "performance"
+   }
+}
+----
+
+|`platform.openstack.ingressFloatingIP`
+|An existing floating IP address to associate with the Ingress port. To use this property, you must also define the `platform.openstack.externalNetwork` property.
+|An IP address, for example `128.0.0.1`.
+
+|`platform.openstack.apiFloatingIP`
+|An existing floating IP address to associate with the API load balancer. To use this property, you must also define the `platform.openstack.externalNetwork` property.
+|An IP address, for example `128.0.0.1`.
+
+|`platform.openstack.externalDNS`
+|IP addresses for external DNS servers that cluster instances use for DNS resolution.
+|A list of IP addresses as strings. For example, `["8.8.8.8", "192.168.1.12"]`.
+
+|`platform.openstack.machinesSubnet`
+|The UUID of a {rh-openstack} subnet that the cluster's nodes use. Nodes and virtual IP (VIP) ports are created on this subnet.
+
+The first item in `networking.machineNetwork` must match the value of `machinesSubnet`.
+
+If you deploy to a custom subnet, you cannot specify an external DNS server to the {product-title} installer. Instead, link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/subnet[add DNS to the subnet in {rh-openstack}].
+
+|A UUID as a string. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+|====
+endif::osp[]
+
+ifdef::azure[]
+[id="installation-configuration-parameters-additional-azure_{context}"]
+== Additional Azure configuration parameters
+
+Additional Azure configuration parameters are described in the following table:
+
+.Additional Azure parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`controlPlane.platform.azure.osDisk.diskSizeGB`
+|The Azure disk size for the VM.
+|Integer that represents the size of the disk in GB. The minimum supported disk size is `1024`.
+
+|`platform.azure.baseDomainResourceGroupName`
+|The name of the resource group that contains the DNS zone for your base domain.
+|String, for example `production_cluster`.
+
+|`platform.azure.resourceGroupName`
+| The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster using the installation program deletes this resource group.
+|String, for example `existing_resource_group`.
+
+|`platform.azure.outboundType`
+|The outbound routing strategy used to connect your cluster to the internet. If
+you are using user-defined routing, you must have pre-existing networking
+available where the outbound routing has already been configured prior to
+installing a cluster. The installation program is not responsible for
+configuring user-defined routing.
+|`LoadBalancer` or `UserDefinedRouting`. The default is `LoadBalancer`.
+
+|`platform.azure.region`
+|The name of the Azure region that hosts your cluster.
+|Any valid region name, such as `centralus`.
+
+|`platform.azure.zone`
+|List of availability zones to place machines in. For high availability, specify
+at least two zones.
+|List of zones, for example `["1", "2", "3"]`.
+
+|`platform.azure.networkResourceGroupName`
+|The name of the resource group that contains the existing VNet that you want to deploy your cluster to. This name cannot be the same as the `platform.azure.baseDomainResourceGroupName`.
+|String.
+
+|`platform.azure.virtualNetwork`
+|The name of the existing VNet that you want to deploy your cluster to.
+|String.
+
+|`platform.azure.controlPlaneSubnet`
+|The name of the existing subnet in your VNet that you want to deploy your control plane machines to.
+|Valid CIDR, for example `10.0.0.0/16`.
+
+|`platform.azure.computeSubnet`
+|The name of the existing subnet in your VNet that you want to deploy your compute machines to.
+|Valid CIDR, for example `10.0.0.0/16`.
+
+|`platform.azure.cloudName`
+|The name of the Azure cloud environment that is used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the default value `AzurePublicCloud` is used.
+|Any valid cloud environment, such as `AzurePublicCloud` or `AzureUSGovernmentCloud`.
+
+|====
+
+[NOTE]
+====
+You cannot customize
+link:https://azure.microsoft.com/en-us/global-infrastructure/availability-zones/[Azure Availability Zones]
+or
+link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-using-tags[Use tags to organize your Azure resources]
+with an Azure cluster.
+====
+endif::azure[]
+
+ifdef::gcp[]
+[id="installation-configuration-parameters-additional-gcp_{context}"]
+== Additional Google Cloud Platform (GCP) configuration parameters
+
+Additional GCP configuration parameters are described in the following table:
+
+.Additional GCP parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`platform.gcp.network`
+|The name of the existing VPC that you want to deploy your cluster to.
+|String.
+
+|`platform.gcp.region`
+|The name of the GCP region that hosts your cluster.
+|Any valid region name, such as `us-central1`.
+
+|`platform.gcp.type`
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type].
+|The GCP machine type.
+
+|`platform.gcp.zones`
+|The availability zones where the installation program creates machines for the specified MachinePool.
+|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
+|`platform.gcp.controlPlaneSubnet`
+|The name of the existing subnet in your VPC that you want to deploy your control plane machines to.
+|The subnet name.
+
+|`platform.gcp.computeSubnet`
+|The name of the existing subnet in your VPC that you want to deploy your compute machines to.
+|The subnet name.
+
+|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.name`
+|The name of the customer managed encryption key to be used for control plane machine disk encryption.
+|The encryption key name.
+
+|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.keyRing`
+|For control plane machines, the name of the KMS key ring to which the KMS key belongs.
+|The KMS key ring name.
+
+|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.location`
+|For control plane machines, the GCP location in which the key ring exists. For more information on KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
+|The GCP location for the key ring.
+
+|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
+|For control plane machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
+|The GCP project ID.
+
+////
+`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+
+The GCP Compute Engine System service account used for the encryption request for the given KMS key. The Compute Engine default service account is always used for control plane machines during installation, which follows this pattern: `service-<project_number>@compute-system.iam.gserviceaccount.com`. The default service account must have access to the KMS key specified for the control plane machines. The custom service account defined is available for use during post-installation operations. For more information on GCP service accounts, see Google's documentation on link:https://cloud.google.com/iam/docs/service-accounts#types[Types of service accounts].
+
+The GCP Compute Engine System service account email, like `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
+////
+// kmsKeyServiceAccount not yet fully supported in 4.7. Re-add when more stable.
+
+|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.name`
+|The name of the customer managed encryption key to be used for compute machine disk encryption.
+|The encryption key name.
+
+|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.keyRing`
+|For compute machines, the name of the KMS key ring to which the KMS key belongs.
+|The KMS key ring name.
+
+|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.location`
+|For compute machines, the GCP location in which the key ring exists. For more information on KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
+|The GCP location for the key ring.
+
+|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
+|For compute machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
+|The GCP project ID.
+
+////
+`compute.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+
+For compute machines, the GCP Compute Engine System service account used for the encryption request for the given KMS key. If left undefined, the Compute Engine default service account is used, which follows this pattern: `service-<project_number>@compute-system.iam.gserviceaccount.com`. For more information on GCP service accounts, see Google's documentation on link:https://cloud.google.com/iam/docs/service-accounts#types[Types of service accounts].
+
+The GCP Compute Engine System service account email, like `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
+////
+// kmsKeyServiceAccount not yet fully supported in 4.7. Re-add when more stable.
+|====
+
+endif::gcp[]
+
+ifdef::rhv[]
+[id="installation-configuration-parameters-additional-rhv_{context}"]
+== Additional {rh-virtualization-first} configuration parameters
+
+Additional {rh-virtualization} configuration parameters are described in the following table:
+
+[id="additional-virt-parameters-for-clusters_{context}"]
+.Additional {rh-virtualization-first} parameters for clusters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`platform.ovirt.ovirt_cluster_id`
+|Required. The Cluster where the VMs will be created.
+|String. For example: `68833f9f-e89c-4891-b768-e2ba0815b76b`
+
+|`platform.ovirt.ovirt_storage_domain_id`
+|Required. The Storage Domain ID where the VM disks will be created.
+|String. For example: `ed7b0f4e-0e96-492a-8fff-279213ee1468`
+
+|`platform.ovirt.ovirt_network_name`
+|Required. The network name where the VM nics will be created.
+|String. For example: `ocpcluster`
+
+|`platform.ovirt.vnicProfileID`
+|Required. The vNIC profile ID of the VM network interfaces. This can be inferred if the cluster network has a single profile.
+|String. For example: `3fa86930-0be5-4052-b667-b79f0a729692`
+
+|`platform.ovirt.api_vip`
+|Required. An IP address on the machine network that will be assigned to the API virtual IP (VIP). You can access the OpenShift API at this endpoint.
+|String. Example: `10.46.8.230`
+
+|`platform.ovirt.ingress_vip`
+|Required. An IP address on the machine network that will be assigned to the Ingress virtual IP (VIP).
+|String. Example: `10.46.8.232`
+
+|`platform.ovirt.affinityGroups`
+|Optional. A list of affinity groups to create during the installation process.
+|List of objects.
+
+|`platform.ovirt.affinityGroups.description`
+|Required if you include `platform.ovirt.affinityGroups`. A description of the affinity group.
+|String. Example: `AffinityGroup for spreading each compute machine to a different host`
+
+|`platform.ovirt.affinityGroups.enforcing`
+|Required if you include `platform.ovirt.affinityGroups`. When set to `true`, {rh-virtualization} does not provision any machines if not enough hardware nodes are available. When set to `false`, {rh-virtualization} does provision machines even if not enough hardware nodes are available, resulting in multiple virtual machines being hosted on the same physical machine.
+
+|String. Example: `true`
+
+|`platform.ovirt.affinityGroups.name`
+|Required if you include `platform.ovirt.affinityGroups`. The name of the affinity group.
+|String. Example: `compute`
+
+|`platform.ovirt.affinityGroups.priority`
+|Required if you include `platform.ovirt.affinityGroups`. The priority given to an affinity group when `platform.ovirt.affinityGroups.enforcing = false`. {rh-virtualization} applies affinity groups in the order of priority, where a greater number takes precedence over a lesser one. If multiple affinity groups have the same priority, the order in which they are applied is not guaranteed.
+|Integer. Example: `3`
+|====
+
+[id="installation-configuration-parameters-additional-machine_{context}"]
+== Additional {rh-virtualization} parameters for machine pools
+
+Additional {rh-virtualization} configuration parameters for machine pools are described in the following table:
+
+.Additional {rh-virtualization} parameters for machine pools
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`<machine-pool>.platform.ovirt.cpu`
+|Optional. Defines the CPU of the VM.
+|Object
+
+|`<machine-pool>.platform.ovirt.cpu.cores`
+|Required if you use `<machine-pool>.platform.ovirt.cpu`. The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.
+|Integer
+
+|`<machine-pool>.platform.ovirt.cpu.sockets`
+|Required if you use `<machine-pool>.platform.ovirt.cpu`. The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.
+|Integer
+
+|`<machine-pool>.platform.ovirt.memoryMB`
+|Optional. Memory of the VM in MiB.
+|Integer
+
+|`<machine-pool>.platform.ovirt.instanceTypeID`
+|Optional. An instance type UUID, such as `00000009-0009-0009-0009-0000000000f1`, which you can get from the `https://<engine-fqdn>/ovirt-engine/api/instancetypes` endpoint.
+|String of UUID
+
+|`<machine-pool>.platform.ovirt.osDisk`
+|Optional. Defines the first and bootable disk of the VM.
+|String
+
+|`<machine-pool>.platform.ovirt.osDisk.sizeGB`
+|Required if you use `<machine-pool>.platform.ovirt.osDisk`. Size of the disk in GiB.
+|Number
+
+|`<machine-pool>.platform.ovirt.vmType`
+|Optional. The VM workload type, such as `high-performance`, `server`, or `desktop`.  By default, master nodes use `high-performance`, and worker nodes use `server`. For details, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Virtual_Machine_General_settings_explained[Explanation of Settings in the New Virtual Machine and Edit Virtual Machine Windows] and link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
+[NOTE]
+====
+`high_performance` improves performance on the VM, but there are limitations. For example, you cannot access the VM with a graphical console. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
+====
+|String
+
+|`<machine-pool>.platform.ovirt.affinityGroupsNames`
+|Optional. A list of affinity group names that should be applied to the virtual machines. The affinity groups must exist in {rh-virtualization}, or be created during installation as described in _Additional {rh-virtualization} parameters for clusters_ in this topic. This entry can be empty.
+// xref:../../installing/installing_rhv/installing-rhv-customizations.adoc#additional-virt-parameters-for-clusters[Additional {rh-virtualization} parameters for clusters]. This entry can be empty.
+//xref:../../additional-virt-parameters-for-clusters[Additional {rh-virtualization} parameters for clusters]. This entry can be empty.
+
+.Example with two affinity groups
+
+This example defines two affinity groups, named `compute` and `clusterWideNonEnforcing`:
+
+[source,yaml]
+----
+<machine-pool>:
+  platform:
+    ovirt:
+      affinityGroupNames:
+        - compute
+        - clusterWideNonEnforcing
+----
+
+This example defines no affinity groups:
+
+[source,yaml]
+----
+<machine-pool>:
+  platform:
+    ovirt:
+      affinityGroupNames: []
+----
+|String
+|`<machine-pool>.platform.ovirt.AutoPinningPolicy`
+| Optional. AutoPinningPolicy defines the policy to automatically set the CPU and NUMA settings, including pinning to the host for the instance. When the field is omitted, the default is `none`. Supported values: `none`, `resize_and_pin`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Setting_NUMA_Nodes[Setting NUMA Nodes] in the _Virtual Machine Management Guide_.
+
+|String
+|`<machine-pool>.platform.ovirt.hugepages`
+|Optional. Hugepages is the size in KiB for defining hugepages in a VM. Supported values: `2048` or `1048576`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_Huge_Pages[Configuring Huge Pages] in the _Virtual Machine Management Guide_.
+
+|Integer
+
+|====
+
+[NOTE]
+====
+You can replace `<machine-pool>` with `controlPlane` or `compute`.
+====
+
+endif::rhv[]
+
+ifdef::vsphere,vmc[]
+[id="installation-configuration-parameters-additional-vsphere_{context}"]
+== Additional VMware vSphere configuration parameters
+
+Additional VMware vSphere configuration parameters are described in the following table:
+
+.Additional VMware vSphere cluster parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`platform.vsphere.vCenter`
+|The fully-qualified hostname or IP address of the vCenter server.
+|String
+
+|`platform.vsphere.username`
+|The user name to use to connect to the vCenter instance with. This user must have at least
+the roles and privileges that are required for
+link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html[static or dynamic persistent volume provisioning]
+in vSphere.
+|String
+
+|`platform.vsphere.password`
+|The password for the vCenter user name.
+|String
+
+|`platform.vsphere.datacenter`
+|The name of the datacenter to use in the vCenter instance.
+|String
+
+|`platform.vsphere.defaultDatastore`
+|The name of the default datastore to use for provisioning volumes.
+|String
+
+|`platform.vsphere.folder`
+|_Optional_. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
+|String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+
+|`platform.vsphere.network`
+|The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
+|String
+
+|`platform.vsphere.cluster`
+|The vCenter cluster to install the {product-title} cluster in.
+|String
+
+|`platform.vsphere.apiVIP`
+|The virtual IP (VIP) address that you configured for control plane API access.
+|An IP address, for example `128.0.0.1`.
+
+|`platform.vsphere.ingressVIP`
+|The virtual IP (VIP) address that you configured for cluster ingress.
+|An IP address, for example `128.0.0.1`.
+|====
+
+[id="installation-configuration-parameters-optional-vsphere_{context}"]
+== Optional VMware vSphere machine pool configuration parameters
+
+Optional VMware vSphere machine pool configuration parameters are described in the following table:
+
+.Optional VMware vSphere machine pool parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`platform.vsphere.clusterOSImage`
+|The location from which the installer downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
+|An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
+
+|`platform.vsphere.osDisk.diskSizeGB`
+|The size of the disk in gigabytes.
+|Integer
+
+|`platform.vsphere.cpus`
+|The total number of virtual processor cores to assign a virtual machine.
+|Integer
+
+|`platform.vsphere.coresPerSocket`
+|The number of cores per socket in a virtual machine. The number of virtual CPUs (vCPUs) on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value is `1`
+|Integer
+
+|`platform.vsphere.memoryMB`
+|The size of a virtual machine's memory in megabytes.
+|Integer
+|====
+
+endif::vsphere,vmc[]
+
+ifdef::bare[]
+:!bare:
+endif::bare[]
+
+
+ifeval::["{context}" == "demo-assembly"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-customizations"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-custom"]
+:!osp:
+:!osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:!osp:
+:!osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user"]
+:!osp:
+:!osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-kuryr"]
+:!osp:
+:!osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-sr-iov"]
+:!osp:
+:!osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
+:!osp:
+:!osp-kuryr:
+endif::[]
+ifeval::["{context}" == "installing-rhv-customizations"]
+:!rhv:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
+:!osp-custom:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!ibm-power:
+endif::[]

--- a/examples/adoc-samples/modules/installation-creating-aws-control-plane.adoc
+++ b/examples/adoc-samples/modules/installation-creating-aws-control-plane.adoc
@@ -1,0 +1,268 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-user-infra.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+
+[id="installation-creating-aws-control-plane_{context}"]
+= Creating the control plane machines in AWS
+
+You must create the control plane machines in Amazon Web Services (AWS) that your cluster will use.
+
+You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources that represent the control plane nodes.
+
+[IMPORTANT]
+====
+The CloudFormation template creates a stack that represents three control plane nodes.
+====
+
+[NOTE]
+====
+If you do not use the provided CloudFormation template to create your control plane
+nodes, you must review the provided information and manually create
+the infrastructure. If your cluster does not initialize correctly, you might
+have to contact Red Hat support with your installation logs.
+====
+
+.Prerequisites
+
+* You configured an AWS account.
+* You added your AWS keys and region to your local AWS profile by running `aws configure`.
+* You generated the Ignition config files for your cluster.
+* You created and configured a VPC and associated subnets in AWS.
+* You created and configured DNS, load balancers, and listeners in AWS.
+* You created the security groups and roles required for your cluster in AWS.
+* You created the bootstrap machine.
+
+.Procedure
+
+. Create a JSON file that contains the parameter values that the template
+requires:
++
+[source,json]
+----
+[
+  {
+    "ParameterKey": "InfrastructureName", <1>
+    "ParameterValue": "mycluster-<random_string>" <2>
+  },
+  {
+    "ParameterKey": "RhcosAmi", <3>
+    "ParameterValue": "ami-<random_string>" <4>
+  },
+  {
+    "ParameterKey": "AutoRegisterDNS", <5>
+    "ParameterValue": "yes" <6>
+  },
+  {
+    "ParameterKey": "PrivateHostedZoneId", <7>
+    "ParameterValue": "<random_string>" <8>
+  },
+  {
+    "ParameterKey": "PrivateHostedZoneName", <9>
+    "ParameterValue": "mycluster.example.com" <10>
+  },
+  {
+    "ParameterKey": "Master0Subnet", <11>
+    "ParameterValue": "subnet-<random_string>" <12>
+  },
+  {
+    "ParameterKey": "Master1Subnet", <11>
+    "ParameterValue": "subnet-<random_string>" <12>
+  },
+  {
+    "ParameterKey": "Master2Subnet", <11>
+    "ParameterValue": "subnet-<random_string>" <12>
+  },
+  {
+    "ParameterKey": "MasterSecurityGroupId", <13>
+    "ParameterValue": "sg-<random_string>" <14>
+  },
+  {
+    "ParameterKey": "IgnitionLocation", <15>
+    "ParameterValue": "https://api-int.<cluster_name>.<domain_name>:22623/config/master" <16>
+  },
+  {
+    "ParameterKey": "CertificateAuthorities", <17>
+    "ParameterValue": "data:text/plain;charset=utf-8;base64,ABC...xYz==" <18>
+  },
+  {
+    "ParameterKey": "MasterInstanceProfileName", <19>
+    "ParameterValue": "<roles_stack>-MasterInstanceProfile-<random_string>" <20>
+  },
+  {
+    "ParameterKey": "MasterInstanceType", <21>
+    "ParameterValue": "m5.xlarge" <22>
+  },
+  {
+    "ParameterKey": "AutoRegisterELB", <23>
+    "ParameterValue": "yes" <24>
+  },
+  {
+    "ParameterKey": "RegisterNlbIpTargetsLambdaArn", <25>
+    "ParameterValue": "arn:aws:lambda:<region>:<account_number>:function:<dns_stack_name>-RegisterNlbIpTargets-<random_string>" <26>
+  },
+  {
+    "ParameterKey": "ExternalApiTargetGroupArn", <27>
+    "ParameterValue": "arn:aws:elasticloadbalancing:<region>:<account_number>:targetgroup/<dns_stack_name>-Exter-<random_string>" <28>
+  },
+  {
+    "ParameterKey": "InternalApiTargetGroupArn", <29>
+    "ParameterValue": "arn:aws:elasticloadbalancing:<region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <30>
+  },
+  {
+    "ParameterKey": "InternalServiceTargetGroupArn", <31>
+    "ParameterValue": "arn:aws:elasticloadbalancing:<region>:<account_number>:targetgroup/<dns_stack_name>-Inter-<random_string>" <32>
+  }
+]
+----
+<1> The name for your cluster infrastructure that is encoded in your Ignition
+config files for the cluster.
+<2> Specify the infrastructure name that you extracted from the Ignition config
+file metadata, which has the format `<cluster-name>-<random-string>`.
+<3> Current{op-system-first} AMI to use for the control plane machines.
+<4> Specify an `AWS::EC2::Image::Id` value.
+<5> Whether or not to perform DNS etcd registration.
+<6> Specify `yes` or `no`. If you specify `yes`, you must provide hosted zone
+information.
+<7> The Route 53 private zone ID to register the etcd targets with.
+<8> Specify the `PrivateHostedZoneId` value from the output of the
+CloudFormation template for DNS and load balancing.
+<9> The Route 53 zone to register the targets with.
+<10> Specify `<cluster_name>.<domain_name>` where `<domain_name>` is the Route 53
+base domain that you used when you generated `install-config.yaml` file for the
+cluster. Do not include the trailing period (.) that is
+displayed in the AWS console.
+<11> A subnet, preferably private, to launch the control plane machines on.
+<12> Specify a subnet from the `PrivateSubnets` value from the output of the
+CloudFormation template for DNS and load balancing.
+<13> The master security group ID to associate with control plane nodes.
+<14> Specify the `MasterSecurityGroupId` value from the output of the
+CloudFormation template for the security group and roles.
+<15> The location to fetch control plane Ignition config file from.
+<16> Specify the generated Ignition config file location,
+`https://api-int.<cluster_name>.<domain_name>:22623/config/master`.
+<17> The base64 encoded certificate authority string to use.
+<18> Specify the value from the `master.ign` file that is in the installation
+directory. This value is the long string with the format
+`data:text/plain;charset=utf-8;base64,ABC...xYz==`.
+<19> The IAM profile to associate with control plane nodes.
+<20> Specify the `MasterInstanceProfile` parameter value from the output of
+the CloudFormation template for the security group and roles.
+<21> The type of AWS instance to use for the control plane machines.
+<22> Allowed values:
+* `m4.xlarge`
+* `m4.2xlarge`
+* `m4.4xlarge`
+* `m4.10xlarge`
+* `m4.16xlarge`
+* `m5.xlarge`
+* `m5.2xlarge`
+* `m5.4xlarge`
+* `m5.8xlarge`
+* `m5.12xlarge`
+* `m5.16xlarge`
+* `m5a.xlarge`
+* `m5a.2xlarge`
+* `m5a.4xlarge`
+* `m5a.8xlarge`
+* `m5a.10xlarge`
+* `m5a.16xlarge`
+* `c4.2xlarge`
+* `c4.4xlarge`
+* `c4.8xlarge`
+* `c5.2xlarge`
+* `c5.4xlarge`
+* `c5.9xlarge`
+* `c5.12xlarge`
+* `c5.18xlarge`
+* `c5.24xlarge`
+* `c5a.2xlarge`
+* `c5a.4xlarge`
+* `c5a.8xlarge`
+* `c5a.12xlarge`
+* `c5a.16xlarge`
+* `c5a.24xlarge`
+* `r4.xlarge`
+* `r4.2xlarge`
+* `r4.4xlarge`
+* `r4.8xlarge`
+* `r4.16xlarge`
+* `r5.xlarge`
+* `r5.2xlarge`
+* `r5.4xlarge`
+* `r5.8xlarge`
+* `r5.12xlarge`
+* `r5.16xlarge`
+* `r5.24xlarge`
+* `r5a.xlarge`
+* `r5a.2xlarge`
+* `r5a.4xlarge`
+* `r5a.8xlarge`
+* `r5a.12xlarge`
+* `r5a.16xlarge`
+* `r5a.24xlarge`
+<23> Whether or not to register a network load balancer (NLB).
+<24> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
+Amazon Resource Name (ARN) value.
+<25> The ARN for NLB IP target registration lambda group.
+<26> Specify the `RegisterNlbIpTargetsLambda` value from the output of the CloudFormation template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
+GovCloud region.
+<27> The ARN for external API load balancer target group.
+<28> Specify the `ExternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
+GovCloud region.
+<29> The ARN for internal API load balancer target group.
+<30> Specify the `InternalApiTargetGroupArn` value from the output of the CloudFormation template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
+GovCloud region.
+<31> The ARN for internal service load balancer target group.
+<32> Specify the `InternalServiceTargetGroupArn` value from the output of the CloudFormation template for DNS
+and load balancing. Use `arn:aws-us-gov` if deploying the cluster to an AWS
+GovCloud region.
+
+. Copy the template from the *CloudFormation template for control plane machines*
+section of this topic and save it as a YAML file on your computer. This template
+describes the control plane machines that your cluster requires.
+
+. If you specified an `m5` instance type as the value for `MasterInstanceType`,
+add that instance type to the `MasterInstanceType.AllowedValues` parameter
+in the CloudFormation template.
+
+. Launch the CloudFormation template to create a stack of AWS resources that represent the control plane nodes:
++
+[IMPORTANT]
+====
+You must enter the command on a single line.
+====
++
+[source,terminal]
+----
+$ aws cloudformation create-stack --stack-name <name> <1>
+     --template-body file://<template>.yaml <2>
+     --parameters file://<parameters>.json <3>
+----
+<1> `<name>` is the name for the CloudFormation stack, such as `cluster-control-plane`.
+You need the name of this stack if you remove the cluster.
+<2> `<template>` is the relative path to and name of the CloudFormation template
+YAML file that you saved.
+<3> `<parameters>` is the relative path to and name of the CloudFormation
+parameters JSON file.
++
+.Example output
+[source,terminal]
+----
+arn:aws:cloudformation:us-east-1:269333783861:stack/cluster-control-plane/21c7e2b0-2ee2-11eb-c6f6-0aa34627df4b
+----
++
+[NOTE]
+====
+The CloudFormation template creates a stack that represents three control plane nodes.
+====
+
+. Confirm that the template components exist:
++
+[source,terminal]
+----
+$ aws cloudformation describe-stacks --stack-name <name>
+----

--- a/examples/adoc-samples/modules/templates-writing-description.adoc
+++ b/examples/adoc-samples/modules/templates-writing-description.adoc
@@ -1,0 +1,152 @@
+// Module included in the following assemblies:
+//
+// * openshift_images/using-templates.adoc
+
+[id="templates-writing-description_{context}"]
+= Writing the template description
+
+The template description informs you what the template does and helps you find it when searching in the web console. Additional metadata beyond the template name is optional, but useful to have. In addition to general descriptive information, the metadata also includes a set of tags. Useful tags include the name of the language the template is related to for example, Java, PHP, Ruby, and so on.
+
+The following is an example of template description metadata:
+
+[source,yaml]
+----
+kind: Template
+apiVersion: v1
+metadata:
+  name: cakephp-mysql-example <1>
+  annotations:
+    openshift.io/display-name: "CakePHP MySQL Example (Ephemeral)" <2>
+    description: >-
+      An example CakePHP application with a MySQL database. For more information
+      about using this template, including OpenShift considerations, see
+      https://github.com/sclorg/cakephp-ex/blob/master/README.md.
+
+
+      WARNING: Any data stored will be lost upon pod destruction. Only use this
+      template for testing." <3>
+    openshift.io/long-description: >-
+      This template defines resources needed to develop a CakePHP application,
+      including a build configuration, application DeploymentConfig, and
+      database DeploymentConfig.  The database is stored in
+      non-persistent storage, so this configuration should be used for
+      experimental purposes only. <4>
+    tags: "quickstart,php,cakephp" <5>
+    iconClass: icon-php <6>
+    openshift.io/provider-display-name: "Red Hat, Inc." <7>
+    openshift.io/documentation-url: "https://github.com/sclorg/cakephp-ex" <8>
+    openshift.io/support-url: "https://access.redhat.com" <9>
+message: "Your admin credentials are ${ADMIN_USERNAME}:${ADMIN_PASSWORD}" <10>
+----
+<1> The unique name of the template.
+<2> A brief, user-friendly name, which can be employed by user interfaces.
+<3> A description of the template. Include enough detail that users understand what is being deployed and any caveats they must know before deploying. It should also provide links to additional information, such as a README file. Newlines can be included to create paragraphs.
+<4> Additional template description. This may be displayed by the service catalog, for example.
+<5> Tags to be associated with the template for searching and grouping. Add tags that include it into one of the provided catalog categories. Refer to the `id` and `categoryAliases` in `CATALOG_CATEGORIES` in the console constants file.
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+The categories can also be customized for the whole cluster.
+endif::[]
+<6> An icon to be displayed with your template in the web console.
++
+.Available icons
+[%collapsible]
+====
+* `icon-3scale`
+* `icon-aerogear`
+* `icon-amq`
+* `icon-angularjs`
+* `icon-ansible`
+* `icon-apache`
+* `icon-beaker`
+* `icon-camel`
+* `icon-capedwarf`
+* `icon-cassandra`
+* `icon-catalog-icon`
+* `icon-clojure`
+* `icon-codeigniter`
+* `icon-cordova`
+* `icon-datagrid`
+* `icon-datavirt`
+* `icon-debian`
+* `icon-decisionserver`
+* `icon-django`
+* `icon-dotnet`
+* `icon-drupal`
+* `icon-eap`
+* `icon-elastic`
+* `icon-erlang`
+* `icon-fedora`
+* `icon-freebsd`
+* `icon-git`
+* `icon-github`
+* `icon-gitlab`
+* `icon-glassfish`
+* `icon-go-gopher`
+* `icon-golang`
+* `icon-grails`
+* `icon-hadoop`
+* `icon-haproxy`
+* `icon-helm`
+* `icon-infinispan`
+* `icon-jboss`
+* `icon-jenkins`
+* `icon-jetty`
+* `icon-joomla`
+* `icon-jruby`
+* `icon-js`
+* `icon-knative`
+* `icon-kubevirt`
+* `icon-laravel`
+* `icon-load-balancer`
+* `icon-mariadb`
+* `icon-mediawiki`
+* `icon-memcached`
+* `icon-mongodb`
+* `icon-mssql`
+* `icon-mysql-database`
+* `icon-nginx`
+* `icon-nodejs`
+* `icon-openjdk`
+* `icon-openliberty`
+* `icon-openshift`
+* `icon-openstack`
+* `icon-other-linux`
+* `icon-other-unknown`
+* `icon-perl`
+* `icon-phalcon`
+* `icon-php`
+* `icon-play`
+* `iconpostgresql`
+* `icon-processserver`
+* `icon-python`
+* `icon-quarkus`
+* `icon-rabbitmq`
+* `icon-rails`
+* `icon-redhat`
+* `icon-redis`
+* `icon-rh-integration`
+* `icon-rh-spring-boot`
+* `icon-rh-tomcat`
+* `icon-ruby`
+* `icon-scala`
+* `icon-serverlessfx`
+* `icon-shadowman`
+* `icon-spring-boot`
+* `icon-spring`
+* `icon-sso`
+* `icon-stackoverflow`
+* `icon-suse`
+* `icon-symfony`
+* `icon-tomcat`
+* `icon-ubuntu`
+* `icon-vertx`
+* `icon-wildfly`
+* `icon-windows`
+* `icon-wordpress`
+* `icon-xamarin`
+* `icon-zend`
+====
+<7> The name of the person or organization providing the template.
+<8> A URL referencing further documentation for the template.
+<9> A URL where support can be obtained for the template.
+<10> An instructional message that is displayed when this template is instantiated. This field should inform the user how to use the newly created resources. Parameter substitution is performed on the message before being displayed so that generated credentials and other parameters can be included in the output. Include links to any next-steps documentation that users should follow.

--- a/examples/adoc-samples/modules/templates-writing-parameters.adoc
+++ b/examples/adoc-samples/modules/templates-writing-parameters.adoc
@@ -1,0 +1,138 @@
+// Module included in the following assemblies:
+//
+// * openshift_images/using-templates.adoc
+
+[id="templates-writing-parameters_{context}"]
+= Writing template parameters
+
+Parameters allow a value to be supplied by you or generated when the template is instantiated. Then, that value is substituted wherever the parameter is referenced. References can be defined in any field in the objects list field. This is useful for generating random passwords or allowing you to supply a hostname or other user-specific value that is required to customize the template. Parameters can be referenced in two ways:
+
+* As a string value by placing values in the form `${PARAMETER_NAME}` in any string field in the template.
+
+* As a JSON or YAML value by placing values in the form `${PARAMETER_NAME}` in place of any field in the template.
+
+When using the `${PARAMETER_NAME}` syntax, multiple parameter references can be combined in a single field and the reference can be embedded within fixed data, such as `"http://${PARAMETER_1}${PARAMETER_2}"`. Both parameter values are substituted and the resulting value is a quoted string.
+
+When using the `${PARAMETER_NAME}` syntax only a single parameter reference is allowed and leading and trailing characters are not permitted. The resulting value is unquoted unless, after substitution is performed, the result is not a valid JSON object. If the result is not a valid JSON value, the resulting value is quoted and treated as a standard string.
+
+A single parameter can be referenced multiple times within a template and it can be referenced using both substitution syntaxes within a single template.
+
+A default value can be provided, which is used if you do not supply a different value:
+
+The following is an example of setting an explicit value as the default value:
+
+[source,yaml]
+----
+parameters:
+  - name: USERNAME
+    description: "The user name for Joe"
+    value: joe
+----
+
+Parameter values can also be generated based on rules specified in the parameter definition, for example generating a parameter value:
+
+[source,yaml]
+----
+parameters:
+  - name: PASSWORD
+    description: "The random user password"
+    generate: expression
+    from: "[a-zA-Z0-9]{12}"
+----
+
+
+In the previous example, processing generates a random password 12 characters long consisting of all upper and lowercase alphabet letters and numbers.
+
+The syntax available is not a full regular expression syntax. However, you can use `\w`, `\d`, `\a`, and `\A` modifiers:
+
+- `[\w]{10}` produces 10 alphabet characters, numbers, and underscores. This
+follows the PCRE standard and is equal to `[a-zA-Z0-9_]{10}`.
+- `[\d]{10}` produces 10 numbers. This is equal to `[0-9]{10}`.
+- `[\a]{10}` produces 10 alphabetical characters. This is equal to
+`[a-zA-Z]{10}`.
+- `[\A]{10}` produces 10 punctuation or symbol characters. This is equal to ``[~!@#$%\^&*()\-_+={}\[\]\\|<,>.?/"';:`]{10}``.
+
+[NOTE]
+====
+Depending on if the template is written in YAML or JSON, and the type of string that the modifier is embedded within, you might need to escape the backslash with a second backslash. The following examples are equivalent:
+
+.Example YAML template with a modifier
+[source,yaml]
+----
+  parameters:
+  - name: singlequoted_example
+    generate: expression
+    from: '[\A]{10}'
+  - name: doublequoted_example
+    generate: expression
+    from: "[\\A]{10}"
+----
+
+.Example JSON template with a modifier
+[source,json]
+----
+{
+    "parameters": [
+       {"name": "json_example",
+        "generate": "expression",
+        "from": "[\\A]{10}"
+       }
+    ]
+}
+----
+====
+
+Here is an example of a full template with parameter definitions and references:
+
+[source,yaml]
+----
+kind: Template
+apiVersion: v1
+metadata:
+  name: my-template
+objects:
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: cakephp-mysql-example
+      annotations:
+        description: Defines how to build the application
+    spec:
+      source:
+        type: Git
+        git:
+          uri: "${SOURCE_REPOSITORY_URL}" <1>
+          ref: "${SOURCE_REPOSITORY_REF}"
+        contextDir: "${CONTEXT_DIR}"
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: frontend
+    spec:
+      replicas: "${{REPLICA_COUNT}}" <2>
+parameters:
+  - name: SOURCE_REPOSITORY_URL <3>
+    displayName: Source Repository URL <4>
+    description: The URL of the repository with your application source code <5>
+    value: https://github.com/sclorg/cakephp-ex.git <6>
+    required: true <7>
+  - name: GITHUB_WEBHOOK_SECRET
+    description: A secret string used to configure the GitHub webhook
+    generate: expression <8>
+    from: "[a-zA-Z0-9]{40}" <9>
+  - name: REPLICA_COUNT
+    description: Number of replicas to run
+    value: "2"
+    required: true
+message: "... The GitHub webhook secret is ${GITHUB_WEBHOOK_SECRET} ..." <10>
+----
+<1> This value is replaced with the value of the `SOURCE_REPOSITORY_URL` parameter when the template is instantiated.
+<2> This value is replaced with the unquoted value of the `REPLICA_COUNT` parameter when the template is instantiated.
+<3> The name of the parameter. This value is used to reference the parameter within the template.
+<4> The user-friendly name for the parameter. This is displayed to users.
+<5> A description of the parameter. Provide more detailed information for the purpose of the parameter, including any constraints on the expected value. Descriptions should use complete sentences to follow the console's text standards. Do not make this a duplicate of the display name.
+<6> A default value for the parameter which is used if you do not override the value when instantiating the template. Avoid using default values for things like passwords, instead use generated parameters in combination with secrets.
+<7> Indicates this parameter is required, meaning you cannot override it with an empty value. If the parameter does not provide a default or generated value, you must supply a value.
+<8> A parameter which has its value generated.
+<9> The input to the generator. In this case, the generator produces a 40 character alphanumeric value including upper and lowercase characters.
+<10> Parameters can be included in the template message. This informs you about generated values.

--- a/examples/adoc-samples/modules/virt-accessing-vm-yaml-ssh.adoc
+++ b/examples/adoc-samples/modules/virt-accessing-vm-yaml-ssh.adoc
@@ -1,0 +1,169 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+[id="virt-accessing-vm-yaml-ssh_{context}"]
+= Accessing a virtual machine via SSH with YAML configurations
+
+You can enable an SSH connection to a virtual machine (VM) without the need to run the `virtctl expose` command. When the YAML file for the VM and the YAML file for the service are configured and applied, the service forwards the SSH traffic to the VM.
+
+The following examples show the configurations for the VM's YAML file and the service YAML file.
+
+.Prerequisites
+* Install the OpenShift CLI (`oc`).
+* Create a namespace for the VM's YAML file by using the `oc create namespace` command and specifying a name for the namespace.
+
+.Procedure
+. In the YAML file for the VM, add the label and a value for exposing the service for SSH connections. Enable the `masquerade` feature for the interface:
++
+.Example `VirtualMachine` definition
+[source,yaml]
+----
+...
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  namespace: ssh-ns <1>
+  name: vm-ssh
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-ssh
+        special: vm-ssh <2>
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          interfaces:
+          - masquerade: {} <3>
+            name: testmasquerade <4>
+          rng: {}
+        machine:
+          type: ""
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: testmasquerade
+        pod: {}
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: kubevirt/fedora-cloud-container-disk-demo
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          userData: |
+            #!/bin/bash
+            echo "fedora" | passwd fedora --stdin
+...
+----
+<1> Name of the namespace created by the `oc create namespace` command.
+<2> Label used by the service to identify the virtual machine instances that are enabled for SSH traffic connections. The label can be any `key:value` pair that is added as a `label` to this YAML file and as a `selector` in the service YAML file.
+<3> The interface type is `masquerade`.
+<4> The name of this interface is `testmasquerade`.
+
+. Create the VM:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create -f __<path_for_the_VM_YAML_file>__
+----
++
+. Start the VM:
++
+[source,terminal]
+----
+$ virtctl start vm-ssh
+----
++
+. In the YAML file for the service, specify the service name, port number, and the target port.
++
+.Example `Service` definition
+[source,yaml]
+----
+...
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-ssh <1>
+  namespace: ssh-ns <2>
+spec:
+  ports:
+  - targetPort: 22 <3>
+    protocol: TCP
+    port: 27017
+  selector:
+    special: vm-ssh <4>
+  type: NodePort
+...
+----
+<1> Name of the SSH service.
+<2> Name of the namespace created by the `oc create namespace` command.
+<3> The target port number for the SSH connection.
+<4> The selector name and value must match the label specified in the YAML file for the VM.
+
+. Create the service:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create -f __<path_for_the_service_YAML_file>__
+----
+
+. Verify that the VM is running:
++
+[source,terminal]
+----
+$ oc get vmi
+----
++
+.Example output
+[source,terminal]
+----
+NAME    AGE     PHASE       IP              NODENAME
+vm-ssh 6s       Running     10.244.196.152  node01
+----
+
+. Check the service to find out which port the service acquired:
++
+[source,terminal]
+----
+$ oc get svc
+----
++
+.Example output
+[source,terminal]
+----
+NAME            TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)           AGE
+svc-ssh     NodePort       10.106.236.208 <none>        27017:30093/TCP   22s
+----
++
+In this example, the service acquired the port number 30093.
+
+. Run the following command to obtain the IP address for the node:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get node __<node_name>__ -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME    STATUS   ROLES   AGE    VERSION  INTERNAL-IP      EXTERNAL-IP
+node01  Ready    worker  6d22h  v1.22.1  192.168.55.101   <none>
+----
+
+. Log in to the VM via SSH by specifying the IP address of the node where the VM is running and the port number. Use the port number displayed by the `oc get svc` command and the IP address of the node displayed by the `oc get node` command. The following example shows the `ssh` command with the username, node's IP address, and the port number:
++
+[source,terminal]
+----
+$ ssh fedora@192.168.55.101 -p 30093
+----

--- a/examples/adoc-samples/modules/virt-document-attributes.adoc
+++ b/examples/adoc-samples/modules/virt-document-attributes.adoc
@@ -1,0 +1,33 @@
+// Standard document attributes to be used in the documentation
+//
+// The following are shared by all documents:
+:toc:
+:toc-title:
+:toclevels: 4
+:experimental:
+//
+// Product content attributes, that is, substitution variables in the files.
+//
+:product-title: OpenShift Container Platform
+:VirtProductName: OpenShift Virtualization
+:ProductRelease:
+:ProductVersion:
+:VirtVersion: 4.8
+:KubeVirtVersion: v0.41.0
+:HCOVersion: 4.8.2
+// :LastHCOVersion:
+:product-build:
+:DownloadURL: registry.access.redhat.com
+:kebab: image:kebab.png[title="Options menu"]
+:delete: image:delete.png[title="Delete"]
+//
+// Book Names:
+//     Defining the book names in document attributes instead of hard-coding them in
+//     the master.adoc files and in link references. This makes it easy to change the
+//     book name if necessary.
+//     Using the pattern ending in 'BookName' makes it easy to grep for occurrences
+//     throughout the topics
+//
+:Install_BookName: Installing OpenShift Virtualization
+:Using_BookName: Using OpenShift Virtualization
+:RN_BookName: OpenShift Virtualization release notes

--- a/examples/adoc-samples/modules/virt-features-for-storage-matrix.adoc
+++ b/examples/adoc-samples/modules/virt-features-for-storage-matrix.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+
+[id="virt-features-for-storage-matrix_{context}"]
+= {VirtProductName} storage feature matrix
+
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+The following table describes the {VirtProductName} storage types that support VM import.
+endif::[]
+
+[caption=]
+.{VirtProductName} storage feature matrix
+ifdef::virt-features-for-storage[]
+[cols="40%,15%,15%,15%,15%",options="header"]
+|===
+|
+|Virtual machine live migration
+|Host-assisted virtual machine disk cloning
+|Storage-assisted virtual machine disk cloning
+|Virtual machine snapshots
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+[cols="50%,50%",options="header",caption]
+|===
+|
+|RHV VM import
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+[cols="50%,50%",options="header",caption]
+|===
+|
+|VMware VM import
+endif::[]
+
+|OpenShift Container Storage: RBD block-mode volumes
+ifdef::virt-features-for-storage[]
+|Yes
+|Yes
+|Yes
+|Yes
+endif::[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+|Yes
+endif::[]
+
+|{VirtProductName} hostpath provisioner
+ifdef::virt-features-for-storage[]
+|No
+|Yes
+|No
+|No
+endif::[]
+ifdef::virt-importing-rhv-vm[]
+|No
+endif::[]
+ifdef::virt-importing-vmware-vm[]
+|Yes
+endif::[]
+
+|Other multi-node writable storage
+ifdef::virt-features-for-storage[]
+|Yes ^[1]^
+|Yes
+|Yes ^[2]^
+|Yes ^[2]^
+endif::[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+|Yes ^[1]^
+endif::[]
+
+|Other single-node writable storage
+ifdef::virt-features-for-storage[]
+|No
+|Yes
+|Yes ^[2]^
+|Yes ^[2]^
+endif::[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+|Yes ^[2]^
+endif::[]
+|===
+[.small]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+--
+1. PVCs must request a ReadWriteMany access mode.
+2. PVCs must request a ReadWriteOnce access mode.
+--
+endif::[]
+ifdef::virt-features-for-storage[]
+--
+1. PVCs must request a ReadWriteMany access mode.
+2. Storage provider must support both Kubernetes and CSI snapshot APIs
+--
+endif::[]
+
+ifdef::virt-features-for-storage[]
+[NOTE]
+====
+You cannot live migrate virtual machines that use:
+
+* A storage class with ReadWriteOnce (RWO) access mode
+* Passthrough features such as GPUs or SR-IOV network interfaces that have the `sriovLiveMigration` feature gate disabled 
+
+Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
+====
+endif::[]


### PR DESCRIPTION
See https://issues.redhat.com/browse/CCS-4778

This change includes a new assembly that includes an assortment of modules. The modules contain some complicated asciidoc elements that are, aside from adding an ifeval pair to one module so that it renders correctly in the assembly, unchanged from the versions in the main branch of the https://github.com/openshift/openshift-docs repo.

@wesruv, PTAL? 