### PR TITLE
adding an OCP REST API sample page

### DIFF
--- a/examples/adoc-includes/index.adoc
+++ b/examples/adoc-includes/index.adoc
@@ -1,0 +1,14913 @@
+[id="api-object-reference"]
+= Common object reference
+ifdef::product-title[]
+include::modules/common-attributes.adoc[]
+endif::[]
+
+toc::[]
+
+[id="affinity-core-v1"]
+== Affinity [core/v1]
+
+
+Description::
++
+--
+Affinity is a group of affinity scheduling rules.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `nodeAffinity`
+| xref:../objects/index.adoc#nodeaffinity-core-v1[`NodeAffinity core/v1`]
+| Describes node affinity scheduling rules for the pod.
+
+| `podAffinity`
+| xref:../objects/index.adoc#podaffinity-core-v1[`PodAffinity core/v1`]
+| Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+
+| `podAntiAffinity`
+| xref:../objects/index.adoc#podantiaffinity-core-v1[`PodAntiAffinity core/v1`]
+| Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+
+|===
+
+[id="aggregationrule-rbac-authorization-k8s-io-v1"]
+== AggregationRule [rbac.authorization.k8s.io/v1]
+
+
+Description::
++
+--
+AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `clusterRoleSelectors`
+| xref:../objects/index.adoc#labelselector-meta-v1[`array (LabelSelector meta/v1)`]
+| ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+
+|===
+
+[id="alertmanagerconfiglist-monitoring-coreos-com-v1alpha1"]
+== AlertmanagerConfigList [monitoring.coreos.com/v1alpha1]
+
+
+Description::
++
+--
+AlertmanagerConfigList is a list of AlertmanagerConfig
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.adoc#alertmanagerconfig-monitoring-coreos-com-v1alpha1[`array (AlertmanagerConfig monitoring.coreos.com/v1alpha1)`]
+| List of alertmanagerconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="alertmanagerlist-monitoring-coreos-com-v1"]
+== AlertmanagerList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+AlertmanagerList is a list of Alertmanager
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/alertmanager-monitoring-coreos-com-v1.adoc#alertmanager-monitoring-coreos-com-v1[`array (Alertmanager monitoring.coreos.com/v1)`]
+| List of alertmanagers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="apirequestcountlist-apiserver-openshift-io-v1"]
+== APIRequestCountList [apiserver.openshift.io/v1]
+
+
+Description::
++
+--
+APIRequestCountList is a list of APIRequestCount
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/apirequestcount-apiserver-openshift-io-v1.adoc#apirequestcount-apiserver-openshift-io-v1[`array (APIRequestCount apiserver.openshift.io/v1)`]
+| List of apirequestcounts. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="apiserverlist-config-openshift-io-v1"]
+== APIServerList [config.openshift.io/v1]
+
+
+Description::
++
+--
+APIServerList is a list of APIServer
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/apiserver-config-openshift-io-v1.adoc#apiserver-config-openshift-io-v1[`array (APIServer config.openshift.io/v1)`]
+| List of apiservers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="apiservicelist-apiregistration-k8s-io-v1"]
+== APIServiceList [apiregistration.k8s.io/v1]
+
+
+Description::
++
+--
+APIServiceList is a list of APIService objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../extension_apis/apiservice-apiregistration-k8s-io-v1.adoc#apiservice-apiregistration-k8s-io-v1[`array (APIService apiregistration.k8s.io/v1)`]
+| Items is the list of APIService
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="appliedclusterresourcequotalist-quota-openshift-io-v1"]
+== AppliedClusterResourceQuotaList [quota.openshift.io/v1]
+
+
+Description::
++
+--
+AppliedClusterResourceQuotaList is a collection of AppliedClusterResourceQuotas
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/appliedclusterresourcequota-quota-openshift-io-v1.adoc#appliedclusterresourcequota-quota-openshift-io-v1[`array (AppliedClusterResourceQuota quota.openshift.io/v1)`]
+| Items is a list of AppliedClusterResourceQuota
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="attachedvolume-core-v1"]
+== AttachedVolume [core/v1]
+
+
+Description::
++
+--
+AttachedVolume describes a volume attached to a node
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `devicePath`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `devicePath`
+| `string`
+| DevicePath represents the device path where the volume should be available
+
+| `name`
+| `string`
+| Name of the attached volume
+
+|===
+
+[id="authenticationlist-config-openshift-io-v1"]
+== AuthenticationList [config.openshift.io/v1]
+
+
+Description::
++
+--
+AuthenticationList is a list of Authentication
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/authentication-config-openshift-io-v1.adoc#authentication-config-openshift-io-v1[`array (Authentication config.openshift.io/v1)`]
+| List of authentications. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="authenticationlist-operator-openshift-io-v1"]
+== AuthenticationList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+AuthenticationList is a list of Authentication
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/authentication-operator-openshift-io-v1.adoc#authentication-operator-openshift-io-v1[`array (Authentication operator.openshift.io/v1)`]
+| List of authentications. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="awselasticblockstorevolumesource-core-v1"]
+== AWSElasticBlockStoreVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Persistent Disk resource in AWS.
+
+An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `volumeID`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| `partition`
+| `integer`
+| The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+| `readOnly`
+| `boolean`
+| Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| `volumeID`
+| `string`
+| Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+|===
+
+[id="azurediskvolumesource-core-v1"]
+== AzureDiskVolumeSource [core/v1]
+
+
+Description::
++
+--
+AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `diskName`
+  - `diskURI`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `cachingMode`
+| `string`
+| Host Caching mode: None, Read Only, Read Write.
+
+| `diskName`
+| `string`
+| The Name of the data disk in the blob storage
+
+| `diskURI`
+| `string`
+| The URI the data disk in the blob storage
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `kind`
+| `string`
+| Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+|===
+
+[id="azurefilepersistentvolumesource-core-v1"]
+== AzureFilePersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `secretName`
+  - `shareName`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretName`
+| `string`
+| the name of secret that contains Azure Storage Account Name and Key
+
+| `secretNamespace`
+| `string`
+| the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
+
+| `shareName`
+| `string`
+| Share Name
+
+|===
+
+[id="azurefilevolumesource-core-v1"]
+== AzureFileVolumeSource [core/v1]
+
+
+Description::
++
+--
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `secretName`
+  - `shareName`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretName`
+| `string`
+| the name of secret that contains Azure Storage Account Name and Key
+
+| `shareName`
+| `string`
+| Share Name
+
+|===
+
+[id="baremetalhostlist-metal3-io-v1alpha1"]
+== BareMetalHostList [metal3.io/v1alpha1]
+
+
+Description::
++
+--
+BareMetalHostList is a list of BareMetalHost
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../provisioning_apis/baremetalhost-metal3-io-v1alpha1.adoc#baremetalhost-metal3-io-v1alpha1[`array (BareMetalHost metal3.io/v1alpha1)`]
+| List of baremetalhosts. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="brokertemplateinstancelist-template-openshift-io-v1"]
+== BrokerTemplateInstanceList [template.openshift.io/v1]
+
+
+Description::
++
+--
+BrokerTemplateInstanceList is a list of BrokerTemplateInstance objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../template_apis/brokertemplateinstance-template-openshift-io-v1.adoc#brokertemplateinstance-template-openshift-io-v1[`array (BrokerTemplateInstance template.openshift.io/v1)`]
+| items is a list of BrokerTemplateInstances
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="buildconfiglist-build-openshift-io-v1"]
+== BuildConfigList [build.openshift.io/v1]
+
+
+Description::
++
+--
+BuildConfigList is a collection of BuildConfigs.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/buildconfig-build-openshift-io-v1.adoc#buildconfig-build-openshift-io-v1[`array (BuildConfig build.openshift.io/v1)`]
+| items is a list of build configs
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="buildlist-build-openshift-io-v1"]
+== BuildList [build.openshift.io/v1]
+
+
+Description::
++
+--
+BuildList is a collection of Builds.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/build-build-openshift-io-v1.adoc#build-build-openshift-io-v1[`array (Build build.openshift.io/v1)`]
+| items is a list of builds
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="buildlist-config-openshift-io-v1"]
+== BuildList [config.openshift.io/v1]
+
+
+Description::
++
+--
+BuildList is a list of Build
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/build-config-openshift-io-v1.adoc#build-config-openshift-io-v1[`array (Build config.openshift.io/v1)`]
+| List of builds. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="buildlog-build-openshift-io-v1"]
+== BuildLog [build.openshift.io/v1]
+
+
+Description::
++
+--
+BuildLog is the (unused) resource associated with the build log redirector
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="buildrequest-build-openshift-io-v1"]
+== BuildRequest [build.openshift.io/v1]
+
+
+Description::
++
+--
+BuildRequest is the resource used to pass parameters to build generator
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `binary`
+| xref:../objects/index.adoc#binarybuildsource-build-openshift-io-v1[`BinaryBuildSource build.openshift.io/v1`]
+| binary indicates a request to build from a binary provided to the builder
+
+| `dockerStrategyOptions`
+| xref:../objects/index.adoc#dockerstrategyoptions-build-openshift-io-v1[`DockerStrategyOptions build.openshift.io/v1`]
+| DockerStrategyOptions contains additional docker-strategy specific options for the build
+
+| `env`
+| xref:../objects/index.adoc#envvar_v2-core-v1[`array (EnvVar_v2 core/v1)`]
+| env contains additional environment variables you want to pass into a builder container.
+
+| `from`
+| xref:../objects/index.adoc#objectreference_v2-core-v1[`ObjectReference_v2 core/v1`]
+| from is the reference to the ImageStreamTag that triggered the build.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `lastVersion`
+| `integer`
+| lastVersion (optional) is the LastVersion of the BuildConfig that was used to generate the build. If the BuildConfig in the generator doesn't match, a build will not be generated.
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| 
+
+| `revision`
+| xref:../objects/index.adoc#sourcerevision-build-openshift-io-v1[`SourceRevision build.openshift.io/v1`]
+| revision is the information from the source for a specific repo snapshot.
+
+| `sourceStrategyOptions`
+| xref:../objects/index.adoc#sourcestrategyoptions-build-openshift-io-v1[`SourceStrategyOptions build.openshift.io/v1`]
+| SourceStrategyOptions contains additional source-strategy specific options for the build
+
+| `triggeredBy`
+| xref:../objects/index.adoc#buildtriggercause-build-openshift-io-v1[`array (BuildTriggerCause build.openshift.io/v1)`]
+| triggeredBy describes which triggers started the most recent update to the build configuration and contains information about those triggers.
+
+| `triggeredByImage`
+| xref:../objects/index.adoc#objectreference_v2-core-v1[`ObjectReference_v2 core/v1`]
+| triggeredByImage is the Image that triggered this build.
+
+|===
+
+[id="capabilities-core-v1"]
+== Capabilities [core/v1]
+
+
+Description::
++
+--
+Adds and removes POSIX capabilities from running containers.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `add`
+| `array (string)`
+| Added capabilities
+
+| `drop`
+| `array (string)`
+| Removed capabilities
+
+|===
+
+[id="catalogsourcelist-operators-coreos-com-v1alpha1"]
+== CatalogSourceList [operators.coreos.com/v1alpha1]
+
+
+Description::
++
+--
+CatalogSourceList is a list of CatalogSource
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.adoc#catalogsource-operators-coreos-com-v1alpha1[`array (CatalogSource operators.coreos.com/v1alpha1)`]
+| List of catalogsources. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="cephfspersistentvolumesource-core-v1"]
+== CephFSPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `monitors`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `monitors`
+| `array (string)`
+| Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `path`
+| `string`
+| Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `secretFile`
+| `string`
+| Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `user`
+| `string`
+| Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+|===
+
+[id="cephfsvolumesource-core-v1"]
+== CephFSVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `monitors`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `monitors`
+| `array (string)`
+| Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `path`
+| `string`
+| Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `secretFile`
+| `string`
+| Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| `user`
+| `string`
+| Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+|===
+
+[id="certificatesigningrequestlist-certificates-k8s-io-v1"]
+== CertificateSigningRequestList [certificates.k8s.io/v1]
+
+
+Description::
++
+--
+CertificateSigningRequestList is a collection of CertificateSigningRequest objects
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/certificatesigningrequest-certificates-k8s-io-v1.adoc#certificatesigningrequest-certificates-k8s-io-v1[`array (CertificateSigningRequest certificates.k8s.io/v1)`]
+| items is a collection of CertificateSigningRequest objects
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="cinderpersistentvolumesource-core-v1"]
+== CinderPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `volumeID`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| Optional: points to a secret object containing parameters used to connect to OpenStack.
+
+| `volumeID`
+| `string`
+| volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+|===
+
+[id="cindervolumesource-core-v1"]
+== CinderVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `volumeID`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| Optional: points to a secret object containing parameters used to connect to OpenStack.
+
+| `volumeID`
+| `string`
+| volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+|===
+
+[id="clientipconfig-core-v1"]
+== ClientIPConfig [core/v1]
+
+
+Description::
++
+--
+ClientIPConfig represents the configurations of Client IP based session affinity.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `timeoutSeconds`
+| `integer`
+| timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+
+|===
+
+[id="cloudcredentiallist-operator-openshift-io-v1"]
+== CloudCredentialList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+CloudCredentialList is a list of CloudCredential
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/cloudcredential-operator-openshift-io-v1.adoc#cloudcredential-operator-openshift-io-v1[`array (CloudCredential operator.openshift.io/v1)`]
+| List of cloudcredentials. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusterautoscalerlist-autoscaling-openshift-io-v1"]
+== ClusterAutoscalerList [autoscaling.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterAutoscalerList is a list of ClusterAutoscaler
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../autoscale_apis/clusterautoscaler-autoscaling-openshift-io-v1.adoc#clusterautoscaler-autoscaling-openshift-io-v1[`array (ClusterAutoscaler autoscaling.openshift.io/v1)`]
+| List of clusterautoscalers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clustercsidriverlist-operator-openshift-io-v1"]
+== ClusterCSIDriverList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterCSIDriverList is a list of ClusterCSIDriver
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/clustercsidriver-operator-openshift-io-v1.adoc#clustercsidriver-operator-openshift-io-v1[`array (ClusterCSIDriver operator.openshift.io/v1)`]
+| List of clustercsidrivers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusternetworklist-network-openshift-io-v1"]
+== ClusterNetworkList [network.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterNetworkList is a list of ClusterNetwork
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/clusternetwork-network-openshift-io-v1.adoc#clusternetwork-network-openshift-io-v1[`array (ClusterNetwork network.openshift.io/v1)`]
+| List of clusternetworks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusteroperatorlist-config-openshift-io-v1"]
+== ClusterOperatorList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterOperatorList is a list of ClusterOperator
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/clusteroperator-config-openshift-io-v1.adoc#clusteroperator-config-openshift-io-v1[`array (ClusterOperator config.openshift.io/v1)`]
+| List of clusteroperators. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusterresourcequotalist-quota-openshift-io-v1"]
+== ClusterResourceQuotaList [quota.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterResourceQuotaList is a list of ClusterResourceQuota
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/clusterresourcequota-quota-openshift-io-v1.adoc#clusterresourcequota-quota-openshift-io-v1[`array (ClusterResourceQuota quota.openshift.io/v1)`]
+| List of clusterresourcequotas. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusterrolebindinglist-authorization-openshift-io-v1"]
+== ClusterRoleBindingList [authorization.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterRoleBindingList is a collection of ClusterRoleBindings
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../role_apis/clusterrolebinding-authorization-openshift-io-v1.adoc#clusterrolebinding-authorization-openshift-io-v1[`array (ClusterRoleBinding authorization.openshift.io/v1)`]
+| Items is a list of ClusterRoleBindings
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="clusterrolebindinglist-rbac-authorization-k8s-io-v1"]
+== ClusterRoleBindingList [rbac.authorization.k8s.io/v1]
+
+
+Description::
++
+--
+ClusterRoleBindingList is a collection of ClusterRoleBindings
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../rbac_apis/clusterrolebinding-rbac-authorization-k8s-io-v1.adoc#clusterrolebinding-rbac-authorization-k8s-io-v1[`array (ClusterRoleBinding rbac.authorization.k8s.io/v1)`]
+| Items is a list of ClusterRoleBindings
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata.
+
+|===
+
+[id="clusterrolelist-authorization-openshift-io-v1"]
+== ClusterRoleList [authorization.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterRoleList is a collection of ClusterRoles
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../role_apis/clusterrole-authorization-openshift-io-v1.adoc#clusterrole-authorization-openshift-io-v1[`array (ClusterRole authorization.openshift.io/v1)`]
+| Items is a list of ClusterRoles
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="clusterrolelist-rbac-authorization-k8s-io-v1"]
+== ClusterRoleList [rbac.authorization.k8s.io/v1]
+
+
+Description::
++
+--
+ClusterRoleList is a collection of ClusterRoles
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../rbac_apis/clusterrole-rbac-authorization-k8s-io-v1.adoc#clusterrole-rbac-authorization-k8s-io-v1[`array (ClusterRole rbac.authorization.k8s.io/v1)`]
+| Items is a list of ClusterRoles
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata.
+
+|===
+
+[id="clusterserviceversionlist-operators-coreos-com-v1alpha1"]
+== ClusterServiceVersionList [operators.coreos.com/v1alpha1]
+
+
+Description::
++
+--
+ClusterServiceVersionList is a list of ClusterServiceVersion
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/clusterserviceversion-operators-coreos-com-v1alpha1.adoc#clusterserviceversion-operators-coreos-com-v1alpha1[`array (ClusterServiceVersion operators.coreos.com/v1alpha1)`]
+| List of clusterserviceversions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="clusterversionlist-config-openshift-io-v1"]
+== ClusterVersionList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ClusterVersionList is a list of ClusterVersion
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/clusterversion-config-openshift-io-v1.adoc#clusterversion-config-openshift-io-v1[`array (ClusterVersion config.openshift.io/v1)`]
+| List of clusterversions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="componentcondition-core-v1"]
+== ComponentCondition [core/v1]
+
+
+Description::
++
+--
+Information about the condition of a component.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `error`
+| `string`
+| Condition error code for a component. For example, a health check error code.
+
+| `message`
+| `string`
+| Message about the condition for a component. For example, information about a health check.
+
+| `status`
+| `string`
+| Status of the condition for a component. Valid values for "Healthy": "True", "False", or "Unknown".
+
+| `type`
+| `string`
+| Type of condition for a component. Valid value: "Healthy"
+
+|===
+
+[id="componentstatuslist-core-v1"]
+== ComponentStatusList [core/v1]
+
+
+Description::
++
+--
+Status of all the conditions for the component as a list of ComponentStatus objects. Deprecated: This API is deprecated in v1.19+
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/componentstatus-core-v1.adoc#componentstatus-core-v1[`array (ComponentStatus core/v1)`]
+| List of ComponentStatus objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="condition-meta-v1"]
+== Condition [meta/v1]
+
+
+Description::
++
+--
+Condition contains details for one aspect of the current state of this API Resource.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+  - `lastTransitionTime`
+  - `reason`
+  - `message`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+
+| `message`
+| `string`
+| message is a human readable message indicating details about the transition. This may be an empty string.
+
+| `observedGeneration`
+| `integer`
+| observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+
+| `reason`
+| `string`
+| reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+
+| `status`
+| `string`
+| status of the condition, one of True, False, Unknown.
+
+| `type`
+| `string`
+| type of condition in CamelCase or in foo.example.com/CamelCase.
+
+|===
+
+[id="configlist-imageregistry-operator-openshift-io-v1"]
+== ConfigList [imageregistry.operator.openshift.io/v1]
+
+
+Description::
++
+--
+ConfigList is a list of Config
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/config-imageregistry-operator-openshift-io-v1.adoc#config-imageregistry-operator-openshift-io-v1[`array (Config imageregistry.operator.openshift.io/v1)`]
+| List of configs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="configlist-operator-openshift-io-v1"]
+== ConfigList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+ConfigList is a list of Config
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/config-operator-openshift-io-v1.adoc#config-operator-openshift-io-v1[`array (Config operator.openshift.io/v1)`]
+| List of configs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="configlist-samples-operator-openshift-io-v1"]
+== ConfigList [samples.operator.openshift.io/v1]
+
+
+Description::
++
+--
+ConfigList is a list of Config
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/config-samples-operator-openshift-io-v1.adoc#config-samples-operator-openshift-io-v1[`array (Config samples.operator.openshift.io/v1)`]
+| List of configs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="configmapenvsource-core-v1"]
+== ConfigMapEnvSource [core/v1]
+
+
+Description::
++
+--
+ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the ConfigMap must be defined
+
+|===
+
+[id="configmapkeyselector-core-v1"]
+== ConfigMapKeySelector [core/v1]
+
+
+Description::
++
+--
+Selects a key from a ConfigMap.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| The key to select.
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the ConfigMap or its key must be defined
+
+|===
+
+[id="configmaplist-core-v1"]
+== ConfigMapList [core/v1]
+
+
+Description::
++
+--
+ConfigMapList is a resource containing a list of ConfigMap objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/configmap-core-v1.adoc#configmap-core-v1[`array (ConfigMap core/v1)`]
+| Items is the list of ConfigMaps.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="configmapnodeconfigsource-core-v1"]
+== ConfigMapNodeConfigSource [core/v1]
+
+
+Description::
++
+--
+ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node. This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
+--
+
+Type::
+  `object`
+
+Required::
+  - `namespace`
+  - `name`
+  - `kubeletConfigKey`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `kubeletConfigKey`
+| `string`
+| KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+
+| `name`
+| `string`
+| Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+
+| `namespace`
+| `string`
+| Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+
+| `resourceVersion`
+| `string`
+| ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+| `uid`
+| `string`
+| UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+|===
+
+[id="configmapprojection-core-v1"]
+== ConfigMapProjection [core/v1]
+
+
+Description::
++
+--
+Adapts a ConfigMap into a projected volume.
+
+The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `items`
+| xref:../objects/index.adoc#keytopath-core-v1[`array (KeyToPath core/v1)`]
+| If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the ConfigMap or its keys must be defined
+
+|===
+
+[id="configmapvolumesource-core-v1"]
+== ConfigMapVolumeSource [core/v1]
+
+
+Description::
++
+--
+Adapts a ConfigMap into a volume.
+
+The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `defaultMode`
+| `integer`
+| Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `items`
+| xref:../objects/index.adoc#keytopath-core-v1[`array (KeyToPath core/v1)`]
+| If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the ConfigMap or its keys must be defined
+
+|===
+
+[id="consoleclidownloadlist-console-openshift-io-v1"]
+== ConsoleCLIDownloadList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleCLIDownloadList is a list of ConsoleCLIDownload
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consoleclidownload-console-openshift-io-v1.adoc#consoleclidownload-console-openshift-io-v1[`array (ConsoleCLIDownload console.openshift.io/v1)`]
+| List of consoleclidownloads. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consoleexternalloglinklist-console-openshift-io-v1"]
+== ConsoleExternalLogLinkList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleExternalLogLinkList is a list of ConsoleExternalLogLink
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consoleexternalloglink-console-openshift-io-v1.adoc#consoleexternalloglink-console-openshift-io-v1[`array (ConsoleExternalLogLink console.openshift.io/v1)`]
+| List of consoleexternalloglinks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolelinklist-console-openshift-io-v1"]
+== ConsoleLinkList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleLinkList is a list of ConsoleLink
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consolelink-console-openshift-io-v1.adoc#consolelink-console-openshift-io-v1[`array (ConsoleLink console.openshift.io/v1)`]
+| List of consolelinks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolelist-config-openshift-io-v1"]
+== ConsoleList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleList is a list of Console
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/console-config-openshift-io-v1.adoc#console-config-openshift-io-v1[`array (Console config.openshift.io/v1)`]
+| List of consoles. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolelist-operator-openshift-io-v1"]
+== ConsoleList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleList is a list of Console
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/console-operator-openshift-io-v1.adoc#console-operator-openshift-io-v1[`array (Console operator.openshift.io/v1)`]
+| List of consoles. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolenotificationlist-console-openshift-io-v1"]
+== ConsoleNotificationList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleNotificationList is a list of ConsoleNotification
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consolenotification-console-openshift-io-v1.adoc#consolenotification-console-openshift-io-v1[`array (ConsoleNotification console.openshift.io/v1)`]
+| List of consolenotifications. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolepluginlist-console-openshift-io-v1alpha1"]
+== ConsolePluginList [console.openshift.io/v1alpha1]
+
+
+Description::
++
+--
+ConsolePluginList is a list of ConsolePlugin
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consoleplugin-console-openshift-io-v1alpha1.adoc#consoleplugin-console-openshift-io-v1alpha1[`array (ConsolePlugin console.openshift.io/v1alpha1)`]
+| List of consoleplugins. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consolequickstartlist-console-openshift-io-v1"]
+== ConsoleQuickStartList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleQuickStartList is a list of ConsoleQuickStart
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consolequickstart-console-openshift-io-v1.adoc#consolequickstart-console-openshift-io-v1[`array (ConsoleQuickStart console.openshift.io/v1)`]
+| List of consolequickstarts. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="consoleyamlsamplelist-console-openshift-io-v1"]
+== ConsoleYAMLSampleList [console.openshift.io/v1]
+
+
+Description::
++
+--
+ConsoleYAMLSampleList is a list of ConsoleYAMLSample
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../console_apis/consoleyamlsample-console-openshift-io-v1.adoc#consoleyamlsample-console-openshift-io-v1[`array (ConsoleYAMLSample console.openshift.io/v1)`]
+| List of consoleyamlsamples. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="container-core-v1"]
+== Container [core/v1]
+
+
+Description::
++
+--
+A single application container that you want to run within a pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `args`
+| `array (string)`
+| Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+| `command`
+| `array (string)`
+| Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+| `env`
+| xref:../objects/index.adoc#envvar-core-v1[`array (EnvVar core/v1)`]
+| List of environment variables to set in the container. Cannot be updated.
+
+| `envFrom`
+| xref:../objects/index.adoc#envfromsource-core-v1[`array (EnvFromSource core/v1)`]
+| List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+
+| `image`
+| `string`
+| Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.
+
+| `imagePullPolicy`
+| `string`
+| Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+| `lifecycle`
+| xref:../objects/index.adoc#lifecycle-core-v1[`Lifecycle core/v1`]
+| Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+
+| `livenessProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+| `name`
+| `string`
+| Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+| `ports`
+| xref:../objects/index.adoc#containerport-core-v1[`array (ContainerPort core/v1)`]
+| List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+
+| `readinessProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+| `resources`
+| xref:../objects/index.adoc#resourcerequirements-core-v1[`ResourceRequirements core/v1`]
+| Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `securityContext`
+| xref:../objects/index.adoc#securitycontext-core-v1[`SecurityContext core/v1`]
+| SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+| `startupProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+| `stdin`
+| `boolean`
+| Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+
+| `stdinOnce`
+| `boolean`
+| Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+
+| `terminationMessagePath`
+| `string`
+| Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+
+| `terminationMessagePolicy`
+| `string`
+| Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+| `tty`
+| `boolean`
+| Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+
+| `volumeDevices`
+| xref:../objects/index.adoc#volumedevice-core-v1[`array (VolumeDevice core/v1)`]
+| volumeDevices is the list of block devices to be used by the container.
+
+| `volumeMounts`
+| xref:../objects/index.adoc#volumemount-core-v1[`array (VolumeMount core/v1)`]
+| Pod volumes to mount into the container's filesystem. Cannot be updated.
+
+| `workingDir`
+| `string`
+| Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+|===
+
+[id="containerimage-core-v1"]
+== ContainerImage [core/v1]
+
+
+Description::
++
+--
+Describe a container image
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `names`
+| `array (string)`
+| Names by which this image is known. e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+
+| `sizeBytes`
+| `integer`
+| The size of the image in bytes.
+
+|===
+
+[id="containerport-core-v1"]
+== ContainerPort [core/v1]
+
+
+Description::
++
+--
+ContainerPort represents a network port in a single container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `containerPort`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `containerPort`
+| `integer`
+| Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+
+| `hostIP`
+| `string`
+| What host IP to bind the external port to.
+
+| `hostPort`
+| `integer`
+| Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+
+| `name`
+| `string`
+| If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+
+| `protocol`
+| `string`
+| Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+|===
+
+[id="containerruntimeconfiglist-machineconfiguration-openshift-io-v1"]
+== ContainerRuntimeConfigList [machineconfiguration.openshift.io/v1]
+
+
+Description::
++
+--
+ContainerRuntimeConfigList is a list of ContainerRuntimeConfig
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.adoc#containerruntimeconfig-machineconfiguration-openshift-io-v1[`array (ContainerRuntimeConfig machineconfiguration.openshift.io/v1)`]
+| List of containerruntimeconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="containerstate-core-v1"]
+== ContainerState [core/v1]
+
+
+Description::
++
+--
+ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `running`
+| xref:../objects/index.adoc#containerstaterunning-core-v1[`ContainerStateRunning core/v1`]
+| Details about a running container
+
+| `terminated`
+| xref:../objects/index.adoc#containerstateterminated-core-v1[`ContainerStateTerminated core/v1`]
+| Details about a terminated container
+
+| `waiting`
+| xref:../objects/index.adoc#containerstatewaiting-core-v1[`ContainerStateWaiting core/v1`]
+| Details about a waiting container
+
+|===
+
+[id="containerstaterunning-core-v1"]
+== ContainerStateRunning [core/v1]
+
+
+Description::
++
+--
+ContainerStateRunning is a running state of a container.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `startedAt`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Time at which the container was last (re-)started
+
+|===
+
+[id="containerstateterminated-core-v1"]
+== ContainerStateTerminated [core/v1]
+
+
+Description::
++
+--
+ContainerStateTerminated is a terminated state of a container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `exitCode`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `containerID`
+| `string`
+| Container's ID in the format 'docker://<container_id>'
+
+| `exitCode`
+| `integer`
+| Exit status from the last termination of the container
+
+| `finishedAt`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Time at which the container last terminated
+
+| `message`
+| `string`
+| Message regarding the last termination of the container
+
+| `reason`
+| `string`
+| (brief) reason from the last termination of the container
+
+| `signal`
+| `integer`
+| Signal from the last termination of the container
+
+| `startedAt`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Time at which previous execution of the container started
+
+|===
+
+[id="containerstatewaiting-core-v1"]
+== ContainerStateWaiting [core/v1]
+
+
+Description::
++
+--
+ContainerStateWaiting is a waiting state of a container.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `message`
+| `string`
+| Message regarding why the container is not yet running.
+
+| `reason`
+| `string`
+| (brief) reason the container is not yet running.
+
+|===
+
+[id="controllerconfiglist-machineconfiguration-openshift-io-v1"]
+== ControllerConfigList [machineconfiguration.openshift.io/v1]
+
+
+Description::
++
+--
+ControllerConfigList is a list of ControllerConfig
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/controllerconfig-machineconfiguration-openshift-io-v1.adoc#controllerconfig-machineconfiguration-openshift-io-v1[`array (ControllerConfig machineconfiguration.openshift.io/v1)`]
+| List of controllerconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="controllerrevisionlist-apps-v1"]
+== ControllerRevisionList [apps/v1]
+
+
+Description::
++
+--
+ControllerRevisionList is a resource containing a list of ControllerRevision objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/controllerrevision-apps-v1.adoc#controllerrevision-apps-v1[`array (ControllerRevision apps/v1)`]
+| Items is the list of ControllerRevisions
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="credentialsrequestlist-cloudcredential-openshift-io-v1"]
+== CredentialsRequestList [cloudcredential.openshift.io/v1]
+
+
+Description::
++
+--
+CredentialsRequestList is a list of CredentialsRequest
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[`array (CredentialsRequest cloudcredential.openshift.io/v1)`]
+| List of credentialsrequests. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="cronjoblist-batch-v1"]
+== CronJobList [batch/v1]
+
+
+Description::
++
+--
+CronJobList is a collection of cron jobs.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/cronjob-batch-v1.adoc#cronjob-batch-v1[`array (CronJob batch/v1)`]
+| items is the list of CronJobs.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="csidriverlist-storage-k8s-io-v1"]
+== CSIDriverList [storage.k8s.io/v1]
+
+
+Description::
++
+--
+CSIDriverList is a collection of CSIDriver objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/csidriver-storage-k8s-io-v1.adoc#csidriver-storage-k8s-io-v1[`array (CSIDriver storage.k8s.io/v1)`]
+| items is the list of CSIDriver
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="csinodelist-storage-k8s-io-v1"]
+== CSINodeList [storage.k8s.io/v1]
+
+
+Description::
++
+--
+CSINodeList is a collection of CSINode objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/csinode-storage-k8s-io-v1.adoc#csinode-storage-k8s-io-v1[`array (CSINode storage.k8s.io/v1)`]
+| items is the list of CSINode
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="csipersistentvolumesource-core-v1"]
+== CSIPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents storage that is managed by an external CSI volume driver (Beta feature)
+--
+
+Type::
+  `object`
+
+Required::
+  - `driver`
+  - `volumeHandle`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `controllerExpandSecretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| ControllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+| `controllerPublishSecretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+| `driver`
+| `string`
+| Driver is the name of the driver to use for this volume. Required.
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+
+| `nodePublishSecretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+| `nodeStageSecretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+| `readOnly`
+| `boolean`
+| Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).
+
+| `volumeAttributes`
+| `object (string)`
+| Attributes of the volume to publish.
+
+| `volumeHandle`
+| `string`
+| VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
+
+|===
+
+[id="csisnapshotcontrollerlist-operator-openshift-io-v1"]
+== CSISnapshotControllerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+CSISnapshotControllerList is a list of CSISnapshotController
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/csisnapshotcontroller-operator-openshift-io-v1.adoc#csisnapshotcontroller-operator-openshift-io-v1[`array (CSISnapshotController operator.openshift.io/v1)`]
+| List of csisnapshotcontrollers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="csistoragecapacitylist-storage-k8s-io-v1beta1"]
+== CSIStorageCapacityList [storage.k8s.io/v1beta1]
+
+
+Description::
++
+--
+CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/csistoragecapacity-storage-k8s-io-v1beta1.adoc#csistoragecapacity-storage-k8s-io-v1beta1[`array (CSIStorageCapacity storage.k8s.io/v1beta1)`]
+| Items is the list of CSIStorageCapacity objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="csivolumesource-core-v1"]
+== CSIVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a source location of a volume to mount, managed by an external CSI driver
+--
+
+Type::
+  `object`
+
+Required::
+  - `driver`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `driver`
+| `string`
+| Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+| `nodePublishSecretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+
+| `readOnly`
+| `boolean`
+| Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+| `volumeAttributes`
+| `object (string)`
+| VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+|===
+
+[id="customresourcedefinitionlist-apiextensions-k8s-io-v1"]
+== CustomResourceDefinitionList [apiextensions.k8s.io/v1]
+
+
+Description::
++
+--
+CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../extension_apis/customresourcedefinition-apiextensions-k8s-io-v1.adoc#customresourcedefinition-apiextensions-k8s-io-v1[`array (CustomResourceDefinition apiextensions.k8s.io/v1)`]
+| items list individual CustomResourceDefinition objects
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="daemonendpoint-core-v1"]
+== DaemonEndpoint [core/v1]
+
+
+Description::
++
+--
+DaemonEndpoint contains information about a single Daemon endpoint.
+--
+
+Type::
+  `object`
+
+Required::
+  - `Port`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `Port`
+| `integer`
+| Port number of the given endpoint.
+
+|===
+
+[id="daemonsetlist-apps-v1"]
+== DaemonSetList [apps/v1]
+
+
+Description::
++
+--
+DaemonSetList is a collection of daemon sets.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/daemonset-apps-v1.adoc#daemonset-apps-v1[`array (DaemonSet apps/v1)`]
+| A list of daemon sets.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="deleteoptions-meta-v1"]
+== DeleteOptions [meta/v1]
+
+
+Description::
++
+--
+DeleteOptions may be provided when deleting an API object.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `dryRun`
+| `array (string)`
+| When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed
+
+| `gracePeriodSeconds`
+| `integer`
+| The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `orphanDependents`
+| `boolean`
+| Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.
+
+| `preconditions`
+| xref:../objects/index.adoc#preconditions-meta-v1[`Preconditions meta/v1`]
+| Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.
+
+| `propagationPolicy`
+| `string`
+| Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.
+
+|===
+
+[id="deleteoptions_v2-meta-v1"]
+== DeleteOptions_v2 [meta/v1]
+
+
+Description::
++
+--
+DeleteOptions may be provided when deleting an API object.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `dryRun`
+| `array (string)`
+| When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed
+
+| `gracePeriodSeconds`
+| `integer`
+| The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `orphanDependents`
+| `boolean`
+| Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.
+
+| `preconditions`
+| xref:../objects/index.adoc#preconditions-meta-v1[`Preconditions meta/v1`]
+| Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.
+
+| `propagationPolicy`
+| `string`
+| Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.
+
+|===
+
+[id="deploymentconfiglist-apps-openshift-io-v1"]
+== DeploymentConfigList [apps.openshift.io/v1]
+
+
+Description::
++
+--
+DeploymentConfigList is a collection of deployment configs.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/deploymentconfig-apps-openshift-io-v1.adoc#deploymentconfig-apps-openshift-io-v1[`array (DeploymentConfig apps.openshift.io/v1)`]
+| Items is a list of deployment configs
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="deploymentconfigrollback-apps-openshift-io-v1"]
+== DeploymentConfigRollback [apps.openshift.io/v1]
+
+
+Description::
++
+--
+DeploymentConfigRollback provides the input to rollback generation.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `spec`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| Name of the deployment config that will be rolled back.
+
+| `spec`
+| xref:../objects/index.adoc#deploymentconfigrollbackspec-apps-openshift-io-v1[`DeploymentConfigRollbackSpec apps.openshift.io/v1`]
+| Spec defines the options to rollback generation.
+
+| `updatedAnnotations`
+| `object (string)`
+| UpdatedAnnotations is a set of new annotations that will be added in the deployment config.
+
+|===
+
+[id="deploymentlist-apps-v1"]
+== DeploymentList [apps/v1]
+
+
+Description::
++
+--
+DeploymentList is a list of Deployments.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/deployment-apps-v1.adoc#deployment-apps-v1[`array (Deployment apps/v1)`]
+| Items is the list of Deployments.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata.
+
+|===
+
+[id="deploymentlog-apps-openshift-io-v1"]
+== DeploymentLog [apps.openshift.io/v1]
+
+
+Description::
++
+--
+DeploymentLog represents the logs for a deployment
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="deploymentrequest-apps-openshift-io-v1"]
+== DeploymentRequest [apps.openshift.io/v1]
+
+
+Description::
++
+--
+DeploymentRequest is a request to a deployment config for a new deployment.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `latest`
+  - `force`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `excludeTriggers`
+| `array (string)`
+| ExcludeTriggers instructs the instantiator to avoid processing the specified triggers. This field overrides the triggers from latest and allows clients to control specific logic. This field is ignored if not specified.
+
+| `force`
+| `boolean`
+| Force will try to force a new deployment to run. If the deployment config is paused, then setting this to true will return an Invalid error.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `latest`
+| `boolean`
+| Latest will update the deployment config with the latest state from all triggers.
+
+| `name`
+| `string`
+| Name of the deployment config for requesting a new deployment.
+
+|===
+
+[id="dnslist-config-openshift-io-v1"]
+== DNSList [config.openshift.io/v1]
+
+
+Description::
++
+--
+DNSList is a list of DNS
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/dns-config-openshift-io-v1.adoc#dns-config-openshift-io-v1[`array (DNS config.openshift.io/v1)`]
+| List of dnses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="dnslist-operator-openshift-io-v1"]
+== DNSList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+DNSList is a list of DNS
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/dns-operator-openshift-io-v1.adoc#dns-operator-openshift-io-v1[`array (DNS operator.openshift.io/v1)`]
+| List of dnses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="dnsrecordlist-ingress-operator-openshift-io-v1"]
+== DNSRecordList [ingress.operator.openshift.io/v1]
+
+
+Description::
++
+--
+DNSRecordList is a list of DNSRecord
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/dnsrecord-ingress-operator-openshift-io-v1.adoc#dnsrecord-ingress-operator-openshift-io-v1[`array (DNSRecord ingress.operator.openshift.io/v1)`]
+| List of dnsrecords. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="downwardapiprojection-core-v1"]
+== DownwardAPIProjection [core/v1]
+
+
+Description::
++
+--
+Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `items`
+| xref:../objects/index.adoc#downwardapivolumefile-core-v1[`array (DownwardAPIVolumeFile core/v1)`]
+| Items is a list of DownwardAPIVolume file
+
+|===
+
+[id="downwardapivolumefile-core-v1"]
+== DownwardAPIVolumeFile [core/v1]
+
+
+Description::
++
+--
+DownwardAPIVolumeFile represents information to create the file containing the pod field
+--
+
+Type::
+  `object`
+
+Required::
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fieldRef`
+| xref:../objects/index.adoc#objectfieldselector-core-v1[`ObjectFieldSelector core/v1`]
+| Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+
+| `mode`
+| `integer`
+| Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `path`
+| `string`
+| Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+
+| `resourceFieldRef`
+| xref:../objects/index.adoc#resourcefieldselector-core-v1[`ResourceFieldSelector core/v1`]
+| Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+
+|===
+
+[id="downwardapivolumesource-core-v1"]
+== DownwardAPIVolumeSource [core/v1]
+
+
+Description::
++
+--
+DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `defaultMode`
+| `integer`
+| Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `items`
+| xref:../objects/index.adoc#downwardapivolumefile-core-v1[`array (DownwardAPIVolumeFile core/v1)`]
+| Items is a list of downward API volume file
+
+|===
+
+[id="egressnetworkpolicylist-network-openshift-io-v1"]
+== EgressNetworkPolicyList [network.openshift.io/v1]
+
+
+Description::
++
+--
+EgressNetworkPolicyList is a list of EgressNetworkPolicy
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/egressnetworkpolicy-network-openshift-io-v1.adoc#egressnetworkpolicy-network-openshift-io-v1[`array (EgressNetworkPolicy network.openshift.io/v1)`]
+| List of egressnetworkpolicies. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="egressrouterlist-network-operator-openshift-io-v1"]
+== EgressRouterList [network.operator.openshift.io/v1]
+
+
+Description::
++
+--
+EgressRouterList is a list of EgressRouter
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/egressrouter-network-operator-openshift-io-v1.adoc#egressrouter-network-operator-openshift-io-v1[`array (EgressRouter network.operator.openshift.io/v1)`]
+| List of egressrouters. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="emptydirvolumesource-core-v1"]
+== EmptyDirVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `medium`
+| `string`
+| What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| `sizeLimit`
+| xref:../objects/index.adoc#quantity-api-none[`Quantity api/none`]
+| Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
+
+|===
+
+[id="endpointaddress-core-v1"]
+== EndpointAddress [core/v1]
+
+
+Description::
++
+--
+EndpointAddress is a tuple that describes single IP address.
+--
+
+Type::
+  `object`
+
+Required::
+  - `ip`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `hostname`
+| `string`
+| The Hostname of this endpoint
+
+| `ip`
+| `string`
+| The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
+
+| `nodeName`
+| `string`
+| Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+
+| `targetRef`
+| xref:../objects/index.adoc#objectreference-core-v1[`ObjectReference core/v1`]
+| Reference to object providing the endpoint.
+
+|===
+
+[id="endpointport-core-v1"]
+== EndpointPort [core/v1]
+
+
+Description::
++
+--
+EndpointPort is a tuple that describes a single port.
+--
+
+Type::
+  `object`
+
+Required::
+  - `port`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `appProtocol`
+| `string`
+| The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+
+| `name`
+| `string`
+| The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+
+| `port`
+| `integer`
+| The port number of the endpoint.
+
+| `protocol`
+| `string`
+| The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+
+|===
+
+[id="endpointslicelist-discovery-k8s-io-v1"]
+== EndpointSliceList [discovery.k8s.io/v1]
+
+
+Description::
++
+--
+EndpointSliceList represents a list of endpoint slices
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/endpointslice-discovery-k8s-io-v1.adoc#endpointslice-discovery-k8s-io-v1[`array (EndpointSlice discovery.k8s.io/v1)`]
+| List of endpoint slices
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata.
+
+|===
+
+[id="endpointslist-core-v1"]
+== EndpointsList [core/v1]
+
+
+Description::
++
+--
+EndpointsList is a list of endpoints.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/endpoints-core-v1.adoc#endpoints-core-v1[`array (Endpoints core/v1)`]
+| List of endpoints.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="endpointsubset-core-v1"]
+== EndpointSubset [core/v1]
+
+
+Description::
++
+--
+EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:
+  {
+    Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+    Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+  }
+The resulting set of endpoints can be viewed as:
+    a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+    b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `addresses`
+| xref:../objects/index.adoc#endpointaddress-core-v1[`array (EndpointAddress core/v1)`]
+| IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+
+| `notReadyAddresses`
+| xref:../objects/index.adoc#endpointaddress-core-v1[`array (EndpointAddress core/v1)`]
+| IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+
+| `ports`
+| xref:../objects/index.adoc#endpointport-core-v1[`array (EndpointPort core/v1)`]
+| Port numbers available on the related IP addresses.
+
+|===
+
+[id="envfromsource-core-v1"]
+== EnvFromSource [core/v1]
+
+
+Description::
++
+--
+EnvFromSource represents the source of a set of ConfigMaps
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `configMapRef`
+| xref:../objects/index.adoc#configmapenvsource-core-v1[`ConfigMapEnvSource core/v1`]
+| The ConfigMap to select from
+
+| `prefix`
+| `string`
+| An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+
+| `secretRef`
+| xref:../objects/index.adoc#secretenvsource-core-v1[`SecretEnvSource core/v1`]
+| The Secret to select from
+
+|===
+
+[id="envvar-core-v1"]
+== EnvVar [core/v1]
+
+
+Description::
++
+--
+EnvVar represents an environment variable present in a Container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the environment variable. Must be a C_IDENTIFIER.
+
+| `value`
+| `string`
+| Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+
+| `valueFrom`
+| xref:../objects/index.adoc#envvarsource-core-v1[`EnvVarSource core/v1`]
+| Source for the environment variable's value. Cannot be used if value is not empty.
+
+|===
+
+[id="envvar_v2-core-v1"]
+== EnvVar_v2 [core/v1]
+
+
+Description::
++
+--
+EnvVar represents an environment variable present in a Container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the environment variable. Must be a C_IDENTIFIER.
+
+| `value`
+| `string`
+| Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+
+| `valueFrom`
+| xref:../objects/index.adoc#envvarsource-core-v1[`EnvVarSource core/v1`]
+| Source for the environment variable's value. Cannot be used if value is not empty.
+
+|===
+
+[id="envvarsource-core-v1"]
+== EnvVarSource [core/v1]
+
+
+Description::
++
+--
+EnvVarSource represents a source for the value of an EnvVar.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `configMapKeyRef`
+| xref:../objects/index.adoc#configmapkeyselector-core-v1[`ConfigMapKeySelector core/v1`]
+| Selects a key of a ConfigMap.
+
+| `fieldRef`
+| xref:../objects/index.adoc#objectfieldselector-core-v1[`ObjectFieldSelector core/v1`]
+| Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+
+| `resourceFieldRef`
+| xref:../objects/index.adoc#resourcefieldselector-core-v1[`ResourceFieldSelector core/v1`]
+| Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+
+| `secretKeyRef`
+| xref:../objects/index.adoc#secretkeyselector-core-v1[`SecretKeySelector core/v1`]
+| Selects a key of a secret in the pod's namespace
+
+|===
+
+[id="ephemeralcontainer-core-v1"]
+== EphemeralContainer [core/v1]
+
+
+Description::
++
+--
+An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `args`
+| `array (string)`
+| Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+| `command`
+| `array (string)`
+| Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+| `env`
+| xref:../objects/index.adoc#envvar-core-v1[`array (EnvVar core/v1)`]
+| List of environment variables to set in the container. Cannot be updated.
+
+| `envFrom`
+| xref:../objects/index.adoc#envfromsource-core-v1[`array (EnvFromSource core/v1)`]
+| List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+
+| `image`
+| `string`
+| Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+
+| `imagePullPolicy`
+| `string`
+| Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+| `lifecycle`
+| xref:../objects/index.adoc#lifecycle-core-v1[`Lifecycle core/v1`]
+| Lifecycle is not allowed for ephemeral containers.
+
+| `livenessProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| Probes are not allowed for ephemeral containers.
+
+| `name`
+| `string`
+| Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+
+| `ports`
+| xref:../objects/index.adoc#containerport-core-v1[`array (ContainerPort core/v1)`]
+| Ports are not allowed for ephemeral containers.
+
+| `readinessProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| Probes are not allowed for ephemeral containers.
+
+| `resources`
+| xref:../objects/index.adoc#resourcerequirements-core-v1[`ResourceRequirements core/v1`]
+| Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+
+| `securityContext`
+| xref:../objects/index.adoc#securitycontext-core-v1[`SecurityContext core/v1`]
+| Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+
+| `startupProbe`
+| xref:../objects/index.adoc#probe-core-v1[`Probe core/v1`]
+| Probes are not allowed for ephemeral containers.
+
+| `stdin`
+| `boolean`
+| Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+
+| `stdinOnce`
+| `boolean`
+| Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+
+| `targetContainerName`
+| `string`
+| If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+
+| `terminationMessagePath`
+| `string`
+| Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+
+| `terminationMessagePolicy`
+| `string`
+| Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+| `tty`
+| `boolean`
+| Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+
+| `volumeDevices`
+| xref:../objects/index.adoc#volumedevice-core-v1[`array (VolumeDevice core/v1)`]
+| volumeDevices is the list of block devices to be used by the container.
+
+| `volumeMounts`
+| xref:../objects/index.adoc#volumemount-core-v1[`array (VolumeMount core/v1)`]
+| Pod volumes to mount into the container's filesystem. Cannot be updated.
+
+| `workingDir`
+| `string`
+| Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+|===
+
+[id="ephemeralvolumesource-core-v1"]
+== EphemeralVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents an ephemeral volume that is handled by a normal storage driver.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `volumeClaimTemplate`
+| xref:../objects/index.adoc#persistentvolumeclaimtemplate-core-v1[`PersistentVolumeClaimTemplate core/v1`]
+| Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+Required, must not be nil.
+
+|===
+
+[id="etcdlist-operator-openshift-io-v1"]
+== EtcdList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+EtcdList is a list of Etcd
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/etcd-operator-openshift-io-v1.adoc#etcd-operator-openshift-io-v1[`array (Etcd operator.openshift.io/v1)`]
+| List of etcds. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="eventlist-core-v1"]
+== EventList [core/v1]
+
+
+Description::
++
+--
+EventList is a list of events.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/event-core-v1.adoc#event-core-v1[`array (Event core/v1)`]
+| List of events
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="eventlist-events-k8s-io-v1"]
+== EventList [events.k8s.io/v1]
+
+
+Description::
++
+--
+EventList is a list of Event objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/event-events-k8s-io-v1.adoc#event-events-k8s-io-v1[`array (Event events.k8s.io/v1)`]
+| items is a list of schema objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="eventseries-core-v1"]
+== EventSeries [core/v1]
+
+
+Description::
++
+--
+EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `count`
+| `integer`
+| Number of occurrences in this series up to the last heartbeat time
+
+| `lastObservedTime`
+| xref:../objects/index.adoc#microtime-meta-v1[`MicroTime meta/v1`]
+| Time of the last occurrence observed
+
+|===
+
+[id="eventsource-core-v1"]
+== EventSource [core/v1]
+
+
+Description::
++
+--
+EventSource contains information for an event.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `component`
+| `string`
+| Component from which the event is generated.
+
+| `host`
+| `string`
+| Node name on which the event is generated.
+
+|===
+
+[id="eviction-policy-v1"]
+== Eviction [policy/v1]
+
+
+Description::
++
+--
+Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/<pod name>/evictions.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `deleteOptions`
+| xref:../objects/index.adoc#deleteoptions-meta-v1[`DeleteOptions meta/v1`]
+| DeleteOptions may be provided
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| ObjectMeta describes the pod that is being evicted.
+
+|===
+
+[id="execaction-core-v1"]
+== ExecAction [core/v1]
+
+
+Description::
++
+--
+ExecAction describes a "run in container" action.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `command`
+| `array (string)`
+| Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('\|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+
+|===
+
+[id="fcvolumesource-core-v1"]
+== FCVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `lun`
+| `integer`
+| Optional: FC target lun number
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `targetWWNs`
+| `array (string)`
+| Optional: FC target worldwide names (WWNs)
+
+| `wwids`
+| `array (string)`
+| Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+|===
+
+[id="featuregatelist-config-openshift-io-v1"]
+== FeatureGateList [config.openshift.io/v1]
+
+
+Description::
++
+--
+FeatureGateList is a list of FeatureGate
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/featuregate-config-openshift-io-v1.adoc#featuregate-config-openshift-io-v1[`array (FeatureGate config.openshift.io/v1)`]
+| List of featuregates. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="fieldsv1-meta-v1"]
+== FieldsV1 [meta/v1]
+
+
+Description::
++
+--
+FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
+
+Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
+
+The exact format is defined in sigs.k8s.io/structured-merge-diff
+--
+
+Type::
+  `object`
+
+
+
+[id="flexpersistentvolumesource-core-v1"]
+== FlexPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.
+--
+
+Type::
+  `object`
+
+Required::
+  - `driver`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `driver`
+| `string`
+| Driver is the name of the driver to use for this volume.
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| `options`
+| `object (string)`
+| Optional: Extra command options if any.
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+
+|===
+
+[id="flexvolumesource-core-v1"]
+== FlexVolumeSource [core/v1]
+
+
+Description::
++
+--
+FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+--
+
+Type::
+  `object`
+
+Required::
+  - `driver`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `driver`
+| `string`
+| Driver is the name of the driver to use for this volume.
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| `options`
+| `object (string)`
+| Optional: Extra command options if any.
+
+| `readOnly`
+| `boolean`
+| Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+
+|===
+
+[id="flockervolumesource-core-v1"]
+== FlockerVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `datasetName`
+| `string`
+| Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+| `datasetUUID`
+| `string`
+| UUID of the dataset. This is unique identifier of a Flocker dataset
+
+|===
+
+[id="flowschemalist-flowcontrol-apiserver-k8s-io-v1beta1"]
+== FlowSchemaList [flowcontrol.apiserver.k8s.io/v1beta1]
+
+
+Description::
++
+--
+FlowSchemaList is a list of FlowSchema objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/flowschema-flowcontrol-apiserver-k8s-io-v1beta1.adoc#flowschema-flowcontrol-apiserver-k8s-io-v1beta1[`array (FlowSchema flowcontrol.apiserver.k8s.io/v1beta1)`]
+| `items` is a list of FlowSchemas.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="gcepersistentdiskvolumesource-core-v1"]
+== GCEPersistentDiskVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Persistent Disk resource in Google Compute Engine.
+
+A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `pdName`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| `partition`
+| `integer`
+| The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| `pdName`
+| `string`
+| Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+|===
+
+[id="gitrepovolumesource-core-v1"]
+== GitRepoVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `repository`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `directory`
+| `string`
+| Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+| `repository`
+| `string`
+| Repository URL
+
+| `revision`
+| `string`
+| Commit hash for the specified revision.
+
+|===
+
+[id="glusterfspersistentvolumesource-core-v1"]
+== GlusterfsPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `endpoints`
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `endpoints`
+| `string`
+| EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| `endpointsNamespace`
+| `string`
+| EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| `path`
+| `string`
+| Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+|===
+
+[id="glusterfsvolumesource-core-v1"]
+== GlusterfsVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `endpoints`
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `endpoints`
+| `string`
+| EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| `path`
+| `string`
+| Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+|===
+
+[id="grouplist-user-openshift-io-v1"]
+== GroupList [user.openshift.io/v1]
+
+
+Description::
++
+--
+GroupList is a collection of Groups
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../user_and_group_apis/group-user-openshift-io-v1.adoc#group-user-openshift-io-v1[`array (Group user.openshift.io/v1)`]
+| Items is the list of groups
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="groupversionkind-meta-v1"]
+== GroupVersionKind [meta/v1]
+
+
+Description::
++
+--
+GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling
+--
+
+Type::
+  `object`
+
+Required::
+  - `group`
+  - `version`
+  - `kind`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `group`
+| `string`
+| 
+
+| `kind`
+| `string`
+| 
+
+| `version`
+| `string`
+| 
+
+|===
+
+[id="handler-core-v1"]
+== Handler [core/v1]
+
+
+Description::
++
+--
+Handler defines a specific action that should be taken
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `exec`
+| xref:../objects/index.adoc#execaction-core-v1[`ExecAction core/v1`]
+| One and only one of the following should be specified. Exec specifies the action to take.
+
+| `httpGet`
+| xref:../objects/index.adoc#httpgetaction-core-v1[`HTTPGetAction core/v1`]
+| HTTPGet specifies the http request to perform.
+
+| `tcpSocket`
+| xref:../objects/index.adoc#tcpsocketaction-core-v1[`TCPSocketAction core/v1`]
+| TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+|===
+
+[id="helmchartrepositorylist-helm-openshift-io-v1beta1"]
+== HelmChartRepositoryList [helm.openshift.io/v1beta1]
+
+
+Description::
++
+--
+HelmChartRepositoryList is a list of HelmChartRepository
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/helmchartrepository-helm-openshift-io-v1beta1.adoc#helmchartrepository-helm-openshift-io-v1beta1[`array (HelmChartRepository helm.openshift.io/v1beta1)`]
+| List of helmchartrepositories. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="horizontalpodautoscalerlist-autoscaling-v1"]
+== HorizontalPodAutoscalerList [autoscaling/v1]
+
+
+Description::
++
+--
+list of horizontal pod autoscaler objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../autoscale_apis/horizontalpodautoscaler-autoscaling-v1.adoc#horizontalpodautoscaler-autoscaling-v1[`array (HorizontalPodAutoscaler autoscaling/v1)`]
+| list of horizontal pod autoscaler objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata.
+
+|===
+
+[id="hostalias-core-v1"]
+== HostAlias [core/v1]
+
+
+Description::
++
+--
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `hostnames`
+| `array (string)`
+| Hostnames for the above IP address.
+
+| `ip`
+| `string`
+| IP address of the host file entry.
+
+|===
+
+[id="hostpathvolumesource-core-v1"]
+== HostPathVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `path`
+| `string`
+| Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| `type`
+| `string`
+| Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+|===
+
+[id="hostsubnetlist-network-openshift-io-v1"]
+== HostSubnetList [network.openshift.io/v1]
+
+
+Description::
++
+--
+HostSubnetList is a list of HostSubnet
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/hostsubnet-network-openshift-io-v1.adoc#hostsubnet-network-openshift-io-v1[`array (HostSubnet network.openshift.io/v1)`]
+| List of hostsubnets. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="httpgetaction-core-v1"]
+== HTTPGetAction [core/v1]
+
+
+Description::
++
+--
+HTTPGetAction describes an action based on HTTP Get requests.
+--
+
+Type::
+  `object`
+
+Required::
+  - `port`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `host`
+| `string`
+| Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+
+| `httpHeaders`
+| xref:../objects/index.adoc#httpheader-core-v1[`array (HTTPHeader core/v1)`]
+| Custom headers to set in the request. HTTP allows repeated headers.
+
+| `path`
+| `string`
+| Path to access on the HTTP server.
+
+| `port`
+| xref:../objects/index.adoc#intorstring-util-none[`IntOrString util/none`]
+| Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+
+| `scheme`
+| `string`
+| Scheme to use for connecting to the host. Defaults to HTTP.
+
+|===
+
+[id="httpheader-core-v1"]
+== HTTPHeader [core/v1]
+
+
+Description::
++
+--
+HTTPHeader describes a custom header to be used in HTTP probes
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `value`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| The header field name
+
+| `value`
+| `string`
+| The header field value
+
+|===
+
+[id="identitylist-user-openshift-io-v1"]
+== IdentityList [user.openshift.io/v1]
+
+
+Description::
++
+--
+IdentityList is a collection of Identities
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../user_and_group_apis/identity-user-openshift-io-v1.adoc#identity-user-openshift-io-v1[`array (Identity user.openshift.io/v1)`]
+| Items is the list of identities
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="imagecontentsourcepolicylist-operator-openshift-io-v1alpha1"]
+== ImageContentSourcePolicyList [operator.openshift.io/v1alpha1]
+
+
+Description::
++
+--
+ImageContentSourcePolicyList is a list of ImageContentSourcePolicy
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/imagecontentsourcepolicy-operator-openshift-io-v1alpha1.adoc#imagecontentsourcepolicy-operator-openshift-io-v1alpha1[`array (ImageContentSourcePolicy operator.openshift.io/v1alpha1)`]
+| List of imagecontentsourcepolicies. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="imagelist-config-openshift-io-v1"]
+== ImageList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ImageList is a list of Image
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/image-config-openshift-io-v1.adoc#image-config-openshift-io-v1[`array (Image config.openshift.io/v1)`]
+| List of images. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="imagelist-image-openshift-io-v1"]
+== ImageList [image.openshift.io/v1]
+
+
+Description::
++
+--
+ImageList is a list of Image objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../image_apis/image-image-openshift-io-v1.adoc#image-image-openshift-io-v1[`array (Image image.openshift.io/v1)`]
+| Items is a list of images
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="imageprunerlist-imageregistry-operator-openshift-io-v1"]
+== ImagePrunerList [imageregistry.operator.openshift.io/v1]
+
+
+Description::
++
+--
+ImagePrunerList is a list of ImagePruner
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/imagepruner-imageregistry-operator-openshift-io-v1.adoc#imagepruner-imageregistry-operator-openshift-io-v1[`array (ImagePruner imageregistry.operator.openshift.io/v1)`]
+| List of imagepruners. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="imagestreamlayers-image-openshift-io-v1"]
+== ImageStreamLayers [image.openshift.io/v1]
+
+
+Description::
++
+--
+ImageStreamLayers describes information about the layers referenced by images in this image stream.
+--
+
+Type::
+  `object`
+
+Required::
+  - `blobs`
+  - `images`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `blobs`
+| xref:../objects/index.adoc#imagelayerdata-image-openshift-io-v1[`object (ImageLayerData image.openshift.io/v1)`]
+| blobs is a map of blob name to metadata about the blob.
+
+| `images`
+| xref:../objects/index.adoc#imageblobreferences-image-openshift-io-v1[`object (ImageBlobReferences image.openshift.io/v1)`]
+| images is a map between an image name and the names of the blobs and config that comprise the image.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| 
+
+|===
+
+[id="imagestreamlist-image-openshift-io-v1"]
+== ImageStreamList [image.openshift.io/v1]
+
+
+Description::
++
+--
+ImageStreamList is a list of ImageStream objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../image_apis/imagestream-image-openshift-io-v1.adoc#imagestream-image-openshift-io-v1[`array (ImageStream image.openshift.io/v1)`]
+| Items is a list of imageStreams
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="imagestreamtaglist-image-openshift-io-v1"]
+== ImageStreamTagList [image.openshift.io/v1]
+
+
+Description::
++
+--
+ImageStreamTagList is a list of ImageStreamTag objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../image_apis/imagestreamtag-image-openshift-io-v1.adoc#imagestreamtag-image-openshift-io-v1[`array (ImageStreamTag image.openshift.io/v1)`]
+| Items is the list of image stream tags
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="imagetaglist-image-openshift-io-v1"]
+== ImageTagList [image.openshift.io/v1]
+
+
+Description::
++
+--
+ImageTagList is a list of ImageTag objects. When listing image tags, the image field is not populated. Tags are returned in alphabetical order by image stream and then tag.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../image_apis/imagetag-image-openshift-io-v1.adoc#imagetag-image-openshift-io-v1[`array (ImageTag image.openshift.io/v1)`]
+| Items is the list of image stream tags
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="infrastructurelist-config-openshift-io-v1"]
+== InfrastructureList [config.openshift.io/v1]
+
+
+Description::
++
+--
+InfrastructureList is a list of Infrastructure
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/infrastructure-config-openshift-io-v1.adoc#infrastructure-config-openshift-io-v1[`array (Infrastructure config.openshift.io/v1)`]
+| List of infrastructures. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="ingressclasslist-networking-k8s-io-v1"]
+== IngressClassList [networking.k8s.io/v1]
+
+
+Description::
++
+--
+IngressClassList is a collection of IngressClasses.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/ingressclass-networking-k8s-io-v1.adoc#ingressclass-networking-k8s-io-v1[`array (IngressClass networking.k8s.io/v1)`]
+| Items is the list of IngressClasses.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata.
+
+|===
+
+[id="ingresscontrollerlist-operator-openshift-io-v1"]
+== IngressControllerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+IngressControllerList is a list of IngressController
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`array (IngressController operator.openshift.io/v1)`]
+| List of ingresscontrollers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="ingresslist-config-openshift-io-v1"]
+== IngressList [config.openshift.io/v1]
+
+
+Description::
++
+--
+IngressList is a list of Ingress
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/ingress-config-openshift-io-v1.adoc#ingress-config-openshift-io-v1[`array (Ingress config.openshift.io/v1)`]
+| List of ingresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="ingresslist-networking-k8s-io-v1"]
+== IngressList [networking.k8s.io/v1]
+
+
+Description::
++
+--
+IngressList is a collection of Ingress.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/ingress-networking-k8s-io-v1.adoc#ingress-networking-k8s-io-v1[`array (Ingress networking.k8s.io/v1)`]
+| Items is the list of Ingress.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="installplanlist-operators-coreos-com-v1alpha1"]
+== InstallPlanList [operators.coreos.com/v1alpha1]
+
+
+Description::
++
+--
+InstallPlanList is a list of InstallPlan
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/installplan-operators-coreos-com-v1alpha1.adoc#installplan-operators-coreos-com-v1alpha1[`array (InstallPlan operators.coreos.com/v1alpha1)`]
+| List of installplans. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="intorstring-util-none"]
+== IntOrString [util/none]
+
+
+Description::
++
+--
+IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
+--
+
+Type::
+  `string`
+
+
+
+[id="ippoollist-whereabouts-cni-cncf-io-v1alpha1"]
+== IPPoolList [whereabouts.cni.cncf.io/v1alpha1]
+
+
+Description::
++
+--
+IPPoolList is a list of IPPool
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/ippool-whereabouts-cni-cncf-io-v1alpha1.adoc#ippool-whereabouts-cni-cncf-io-v1alpha1[`array (IPPool whereabouts.cni.cncf.io/v1alpha1)`]
+| List of ippools. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="iscsipersistentvolumesource-core-v1"]
+== ISCSIPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `targetPortal`
+  - `iqn`
+  - `lun`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `chapAuthDiscovery`
+| `boolean`
+| whether support iSCSI Discovery CHAP authentication
+
+| `chapAuthSession`
+| `boolean`
+| whether support iSCSI Session CHAP authentication
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| `initiatorName`
+| `string`
+| Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| `iqn`
+| `string`
+| Target iSCSI Qualified Name.
+
+| `iscsiInterface`
+| `string`
+| iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| `lun`
+| `integer`
+| iSCSI Target Lun number.
+
+| `portals`
+| `array (string)`
+| iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| CHAP Secret for iSCSI target and initiator authentication
+
+| `targetPortal`
+| `string`
+| iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+|===
+
+[id="iscsivolumesource-core-v1"]
+== ISCSIVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `targetPortal`
+  - `iqn`
+  - `lun`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `chapAuthDiscovery`
+| `boolean`
+| whether support iSCSI Discovery CHAP authentication
+
+| `chapAuthSession`
+| `boolean`
+| whether support iSCSI Session CHAP authentication
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| `initiatorName`
+| `string`
+| Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| `iqn`
+| `string`
+| Target iSCSI Qualified Name.
+
+| `iscsiInterface`
+| `string`
+| iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| `lun`
+| `integer`
+| iSCSI Target Lun number.
+
+| `portals`
+| `array (string)`
+| iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| CHAP Secret for iSCSI target and initiator authentication
+
+| `targetPortal`
+| `string`
+| iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+|===
+
+[id="joblist-batch-v1"]
+== JobList [batch/v1]
+
+
+Description::
++
+--
+JobList is a collection of jobs.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/job-batch-v1.adoc#job-batch-v1[`array (Job batch/v1)`]
+| items is the list of Jobs.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="keytopath-core-v1"]
+== KeyToPath [core/v1]
+
+
+Description::
++
+--
+Maps a string key to a path within a volume.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| The key to project.
+
+| `mode`
+| `integer`
+| Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `path`
+| `string`
+| The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+
+|===
+
+[id="kubeapiserverlist-operator-openshift-io-v1"]
+== KubeAPIServerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+KubeAPIServerList is a list of KubeAPIServer
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/kubeapiserver-operator-openshift-io-v1.adoc#kubeapiserver-operator-openshift-io-v1[`array (KubeAPIServer operator.openshift.io/v1)`]
+| List of kubeapiservers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="kubecontrollermanagerlist-operator-openshift-io-v1"]
+== KubeControllerManagerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+KubeControllerManagerList is a list of KubeControllerManager
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/kubecontrollermanager-operator-openshift-io-v1.adoc#kubecontrollermanager-operator-openshift-io-v1[`array (KubeControllerManager operator.openshift.io/v1)`]
+| List of kubecontrollermanagers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="kubeletconfiglist-machineconfiguration-openshift-io-v1"]
+== KubeletConfigList [machineconfiguration.openshift.io/v1]
+
+
+Description::
++
+--
+KubeletConfigList is a list of KubeletConfig
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc#kubeletconfig-machineconfiguration-openshift-io-v1[`array (KubeletConfig machineconfiguration.openshift.io/v1)`]
+| List of kubeletconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="kubeschedulerlist-operator-openshift-io-v1"]
+== KubeSchedulerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+KubeSchedulerList is a list of KubeScheduler
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/kubescheduler-operator-openshift-io-v1.adoc#kubescheduler-operator-openshift-io-v1[`array (KubeScheduler operator.openshift.io/v1)`]
+| List of kubeschedulers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="kubestorageversionmigratorlist-operator-openshift-io-v1"]
+== KubeStorageVersionMigratorList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+KubeStorageVersionMigratorList is a list of KubeStorageVersionMigrator
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/kubestorageversionmigrator-operator-openshift-io-v1.adoc#kubestorageversionmigrator-operator-openshift-io-v1[`array (KubeStorageVersionMigrator operator.openshift.io/v1)`]
+| List of kubestorageversionmigrators. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="labelselector-meta-v1"]
+== LabelSelector [meta/v1]
+
+
+Description::
++
+--
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `matchExpressions`
+| xref:../objects/index.adoc#labelselectorrequirement-meta-v1[`array (LabelSelectorRequirement meta/v1)`]
+| matchExpressions is a list of label selector requirements. The requirements are ANDed.
+
+| `matchLabels`
+| `object (string)`
+| matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+
+|===
+
+[id="labelselectorrequirement-meta-v1"]
+== LabelSelectorRequirement [meta/v1]
+
+
+Description::
++
+--
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+  - `operator`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| key is the label key that the selector applies to.
+
+| `operator`
+| `string`
+| operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+
+| `values`
+| `array (string)`
+| values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+|===
+
+[id="leaselist-coordination-k8s-io-v1"]
+== LeaseList [coordination.k8s.io/v1]
+
+
+Description::
++
+--
+LeaseList is a list of Lease objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/lease-coordination-k8s-io-v1.adoc#lease-coordination-k8s-io-v1[`array (Lease coordination.k8s.io/v1)`]
+| Items is a list of schema objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="lifecycle-core-v1"]
+== Lifecycle [core/v1]
+
+
+Description::
++
+--
+Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `postStart`
+| xref:../objects/index.adoc#handler-core-v1[`Handler core/v1`]
+| PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+| `preStop`
+| xref:../objects/index.adoc#handler-core-v1[`Handler core/v1`]
+| PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+|===
+
+[id="limitrangeitem-core-v1"]
+== LimitRangeItem [core/v1]
+
+
+Description::
++
+--
+LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `default`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Default resource requirement limit value by resource name if resource limit is omitted.
+
+| `defaultRequest`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+
+| `max`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Max usage constraints on this kind by resource name.
+
+| `maxLimitRequestRatio`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+
+| `min`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Min usage constraints on this kind by resource name.
+
+| `type`
+| `string`
+| Type of resource that this limit applies to.
+
+|===
+
+[id="limitrangelist-core-v1"]
+== LimitRangeList [core/v1]
+
+
+Description::
++
+--
+LimitRangeList is a list of LimitRange items.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/limitrange-core-v1.adoc#limitrange-core-v1[`array (LimitRange core/v1)`]
+| Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="listmeta-meta-v1"]
+== ListMeta [meta/v1]
+
+
+Description::
++
+--
+ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `continue`
+| `string`
+| continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+
+| `remainingItemCount`
+| `integer`
+| remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+| `resourceVersion`
+| `string`
+| String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+| `selfLink`
+| `string`
+| selfLink is a URL representing this object. Populated by the system. Read-only.
+
+DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+
+|===
+
+[id="loadbalanceringress-core-v1"]
+== LoadBalancerIngress [core/v1]
+
+
+Description::
++
+--
+LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `hostname`
+| `string`
+| Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+
+| `ip`
+| `string`
+| IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+
+| `ports`
+| xref:../objects/index.adoc#portstatus-core-v1[`array (PortStatus core/v1)`]
+| Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+
+|===
+
+[id="loadbalancerstatus-core-v1"]
+== LoadBalancerStatus [core/v1]
+
+
+Description::
++
+--
+LoadBalancerStatus represents the status of a load-balancer.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `ingress`
+| xref:../objects/index.adoc#loadbalanceringress-core-v1[`array (LoadBalancerIngress core/v1)`]
+| Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+
+|===
+
+[id="localobjectreference-core-v1"]
+== LocalObjectReference [core/v1]
+
+
+Description::
++
+--
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+|===
+
+[id="localobjectreference_v2-core-v1"]
+== LocalObjectReference_v2 [core/v1]
+
+
+Description::
++
+--
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+|===
+
+[id="localvolumesource-core-v1"]
+== LocalVolumeSource [core/v1]
+
+
+Description::
++
+--
+Local represents directly-attached storage with node affinity (Beta feature)
+--
+
+Type::
+  `object`
+
+Required::
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a fileystem if unspecified.
+
+| `path`
+| `string`
+| The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
+
+|===
+
+[id="machineautoscalerlist-autoscaling-openshift-io-v1beta1"]
+== MachineAutoscalerList [autoscaling.openshift.io/v1beta1]
+
+
+Description::
++
+--
+MachineAutoscalerList is a list of MachineAutoscaler
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../autoscale_apis/machineautoscaler-autoscaling-openshift-io-v1beta1.adoc#machineautoscaler-autoscaling-openshift-io-v1beta1[`array (MachineAutoscaler autoscaling.openshift.io/v1beta1)`]
+| List of machineautoscalers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="machineconfiglist-machineconfiguration-openshift-io-v1"]
+== MachineConfigList [machineconfiguration.openshift.io/v1]
+
+
+Description::
++
+--
+MachineConfigList is a list of MachineConfig
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc#machineconfig-machineconfiguration-openshift-io-v1[`array (MachineConfig machineconfiguration.openshift.io/v1)`]
+| List of machineconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="machineconfigpoollist-machineconfiguration-openshift-io-v1"]
+== MachineConfigPoolList [machineconfiguration.openshift.io/v1]
+
+
+Description::
++
+--
+MachineConfigPoolList is a list of MachineConfigPool
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.adoc#machineconfigpool-machineconfiguration-openshift-io-v1[`array (MachineConfigPool machineconfiguration.openshift.io/v1)`]
+| List of machineconfigpools. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="machinehealthchecklist-machine-openshift-io-v1beta1"]
+== MachineHealthCheckList [machine.openshift.io/v1beta1]
+
+
+Description::
++
+--
+MachineHealthCheckList is a list of MachineHealthCheck
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/machinehealthcheck-machine-openshift-io-v1beta1.adoc#machinehealthcheck-machine-openshift-io-v1beta1[`array (MachineHealthCheck machine.openshift.io/v1beta1)`]
+| List of machinehealthchecks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="machinelist-machine-openshift-io-v1beta1"]
+== MachineList [machine.openshift.io/v1beta1]
+
+
+Description::
++
+--
+MachineList is a list of Machine
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/machine-machine-openshift-io-v1beta1.adoc#machine-machine-openshift-io-v1beta1[`array (Machine machine.openshift.io/v1beta1)`]
+| List of machines. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="machinesetlist-machine-openshift-io-v1beta1"]
+== MachineSetList [machine.openshift.io/v1beta1]
+
+
+Description::
++
+--
+MachineSetList is a list of MachineSet
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../machine_apis/machineset-machine-openshift-io-v1beta1.adoc#machineset-machine-openshift-io-v1beta1[`array (MachineSet machine.openshift.io/v1beta1)`]
+| List of machinesets. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="managedfieldsentry-meta-v1"]
+== ManagedFieldsEntry [meta/v1]
+
+
+Description::
++
+--
+ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+
+| `fieldsType`
+| `string`
+| FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
+
+| `fieldsV1`
+| xref:../objects/index.adoc#fieldsv1-meta-v1[`FieldsV1 meta/v1`]
+| FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+
+| `manager`
+| `string`
+| Manager is an identifier of the workflow managing these fields.
+
+| `operation`
+| `string`
+| Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+
+| `subresource`
+| `string`
+| Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+
+| `time`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+
+|===
+
+[id="microtime-meta-v1"]
+== MicroTime [meta/v1]
+
+
+Description::
++
+--
+MicroTime is version of Time with microsecond level precision.
+--
+
+Type::
+  `string`
+
+
+
+[id="mutatingwebhookconfigurationlist-admissionregistration-k8s-io-v1"]
+== MutatingWebhookConfigurationList [admissionregistration.k8s.io/v1]
+
+
+Description::
++
+--
+MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../extension_apis/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1.adoc#mutatingwebhookconfiguration-admissionregistration-k8s-io-v1[`array (MutatingWebhookConfiguration admissionregistration.k8s.io/v1)`]
+| List of MutatingWebhookConfiguration.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="namespacecondition-core-v1"]
+== NamespaceCondition [core/v1]
+
+
+Description::
++
+--
+NamespaceCondition contains details about state of namespace.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| 
+
+| `message`
+| `string`
+| 
+
+| `reason`
+| `string`
+| 
+
+| `status`
+| `string`
+| Status of the condition, one of True, False, Unknown.
+
+| `type`
+| `string`
+| Type of namespace controller condition.
+
+|===
+
+[id="namespacelist-core-v1"]
+== NamespaceList [core/v1]
+
+
+Description::
++
+--
+NamespaceList is a list of Namespaces.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../metadata_apis/namespace-core-v1.adoc#namespace-core-v1[`array (Namespace core/v1)`]
+| Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="netnamespacelist-network-openshift-io-v1"]
+== NetNamespaceList [network.openshift.io/v1]
+
+
+Description::
++
+--
+NetNamespaceList is a list of NetNamespace
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/netnamespace-network-openshift-io-v1.adoc#netnamespace-network-openshift-io-v1[`array (NetNamespace network.openshift.io/v1)`]
+| List of netnamespaces. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="networkattachmentdefinitionlist-k8s-cni-cncf-io-v1"]
+== NetworkAttachmentDefinitionList [k8s.cni.cncf.io/v1]
+
+
+Description::
++
+--
+NetworkAttachmentDefinitionList is a list of NetworkAttachmentDefinition
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/networkattachmentdefinition-k8s-cni-cncf-io-v1.adoc#networkattachmentdefinition-k8s-cni-cncf-io-v1[`array (NetworkAttachmentDefinition k8s.cni.cncf.io/v1)`]
+| List of network-attachment-definitions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="networklist-config-openshift-io-v1"]
+== NetworkList [config.openshift.io/v1]
+
+
+Description::
++
+--
+NetworkList is a list of Network
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/network-config-openshift-io-v1.adoc#network-config-openshift-io-v1[`array (Network config.openshift.io/v1)`]
+| List of networks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="networklist-operator-openshift-io-v1"]
+== NetworkList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+NetworkList is a list of Network
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[`array (Network operator.openshift.io/v1)`]
+| List of networks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="networkpolicylist-networking-k8s-io-v1"]
+== NetworkPolicyList [networking.k8s.io/v1]
+
+
+Description::
++
+--
+NetworkPolicyList is a list of NetworkPolicy objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/networkpolicy-networking-k8s-io-v1.adoc#networkpolicy-networking-k8s-io-v1[`array (NetworkPolicy networking.k8s.io/v1)`]
+| Items is a list of schema objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="nfsvolumesource-core-v1"]
+== NFSVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `server`
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `path`
+| `string`
+| Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| `server`
+| `string`
+| Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+|===
+
+[id="nodeaddress-core-v1"]
+== NodeAddress [core/v1]
+
+
+Description::
++
+--
+NodeAddress contains information for the node's address.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `address`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `address`
+| `string`
+| The node address.
+
+| `type`
+| `string`
+| Node address type, one of Hostname, ExternalIP or InternalIP.
+
+|===
+
+[id="nodeaffinity-core-v1"]
+== NodeAffinity [core/v1]
+
+
+Description::
++
+--
+Node affinity is a group of node affinity scheduling rules.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `preferredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#preferredschedulingterm-core-v1[`array (PreferredSchedulingTerm core/v1)`]
+| The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+
+| `requiredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#nodeselector-core-v1[`NodeSelector core/v1`]
+| If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+
+|===
+
+[id="nodecondition-core-v1"]
+== NodeCondition [core/v1]
+
+
+Description::
++
+--
+NodeCondition contains condition information for a node.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastHeartbeatTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time we got an update on a given condition.
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time the condition transit from one status to another.
+
+| `message`
+| `string`
+| Human readable message indicating details about last transition.
+
+| `reason`
+| `string`
+| (brief) reason for the condition's last transition.
+
+| `status`
+| `string`
+| Status of the condition, one of True, False, Unknown.
+
+| `type`
+| `string`
+| Type of node condition.
+
+|===
+
+[id="nodeconfigsource-core-v1"]
+== NodeConfigSource [core/v1]
+
+
+Description::
++
+--
+NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil. This API is deprecated since 1.22
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `configMap`
+| xref:../objects/index.adoc#configmapnodeconfigsource-core-v1[`ConfigMapNodeConfigSource core/v1`]
+| ConfigMap is a reference to a Node's ConfigMap
+
+|===
+
+[id="nodedaemonendpoints-core-v1"]
+== NodeDaemonEndpoints [core/v1]
+
+
+Description::
++
+--
+NodeDaemonEndpoints lists ports opened by daemons running on the Node.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `kubeletEndpoint`
+| xref:../objects/index.adoc#daemonendpoint-core-v1[`DaemonEndpoint core/v1`]
+| Endpoint on which Kubelet is listening.
+
+|===
+
+[id="nodelist-core-v1"]
+== NodeList [core/v1]
+
+
+Description::
++
+--
+NodeList is the whole list of all Nodes which have been registered with master.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../node_apis/node-core-v1.adoc#node-core-v1[`array (Node core/v1)`]
+| List of nodes
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="nodeselector-core-v1"]
+== NodeSelector [core/v1]
+
+
+Description::
++
+--
+A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+--
+
+Type::
+  `object`
+
+Required::
+  - `nodeSelectorTerms`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `nodeSelectorTerms`
+| xref:../objects/index.adoc#nodeselectorterm-core-v1[`array (NodeSelectorTerm core/v1)`]
+| Required. A list of node selector terms. The terms are ORed.
+
+|===
+
+[id="nodeselectorrequirement-core-v1"]
+== NodeSelectorRequirement [core/v1]
+
+
+Description::
++
+--
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+  - `operator`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| The label key that the selector applies to.
+
+| `operator`
+| `string`
+| Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+| `values`
+| `array (string)`
+| An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+|===
+
+[id="nodeselectorterm-core-v1"]
+== NodeSelectorTerm [core/v1]
+
+
+Description::
++
+--
+A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `matchExpressions`
+| xref:../objects/index.adoc#nodeselectorrequirement-core-v1[`array (NodeSelectorRequirement core/v1)`]
+| A list of node selector requirements by node's labels.
+
+| `matchFields`
+| xref:../objects/index.adoc#nodeselectorrequirement-core-v1[`array (NodeSelectorRequirement core/v1)`]
+| A list of node selector requirements by node's fields.
+
+|===
+
+[id="nodesysteminfo-core-v1"]
+== NodeSystemInfo [core/v1]
+
+
+Description::
++
+--
+NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+--
+
+Type::
+  `object`
+
+Required::
+  - `machineID`
+  - `systemUUID`
+  - `bootID`
+  - `kernelVersion`
+  - `osImage`
+  - `containerRuntimeVersion`
+  - `kubeletVersion`
+  - `kubeProxyVersion`
+  - `operatingSystem`
+  - `architecture`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `architecture`
+| `string`
+| The Architecture reported by the node
+
+| `bootID`
+| `string`
+| Boot ID reported by the node.
+
+| `containerRuntimeVersion`
+| `string`
+| ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+
+| `kernelVersion`
+| `string`
+| Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+
+| `kubeProxyVersion`
+| `string`
+| KubeProxy Version reported by the node.
+
+| `kubeletVersion`
+| `string`
+| Kubelet Version reported by the node.
+
+| `machineID`
+| `string`
+| MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+
+| `operatingSystem`
+| `string`
+| The Operating System reported by the node
+
+| `osImage`
+| `string`
+| OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+
+| `systemUUID`
+| `string`
+| SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+
+|===
+
+[id="oauthaccesstokenlist-oauth-openshift-io-v1"]
+== OAuthAccessTokenList [oauth.openshift.io/v1]
+
+
+Description::
++
+--
+OAuthAccessTokenList is a collection of OAuth access tokens
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../oauth_apis/oauthaccesstoken-oauth-openshift-io-v1.adoc#oauthaccesstoken-oauth-openshift-io-v1[`array (OAuthAccessToken oauth.openshift.io/v1)`]
+| Items is the list of OAuth access tokens
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="oauthauthorizetokenlist-oauth-openshift-io-v1"]
+== OAuthAuthorizeTokenList [oauth.openshift.io/v1]
+
+
+Description::
++
+--
+OAuthAuthorizeTokenList is a collection of OAuth authorization tokens
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../oauth_apis/oauthauthorizetoken-oauth-openshift-io-v1.adoc#oauthauthorizetoken-oauth-openshift-io-v1[`array (OAuthAuthorizeToken oauth.openshift.io/v1)`]
+| Items is the list of OAuth authorization tokens
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="oauthclientauthorizationlist-oauth-openshift-io-v1"]
+== OAuthClientAuthorizationList [oauth.openshift.io/v1]
+
+
+Description::
++
+--
+OAuthClientAuthorizationList is a collection of OAuth client authorizations
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../oauth_apis/oauthclientauthorization-oauth-openshift-io-v1.adoc#oauthclientauthorization-oauth-openshift-io-v1[`array (OAuthClientAuthorization oauth.openshift.io/v1)`]
+| Items is the list of OAuth client authorizations
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="oauthclientlist-oauth-openshift-io-v1"]
+== OAuthClientList [oauth.openshift.io/v1]
+
+
+Description::
++
+--
+OAuthClientList is a collection of OAuth clients
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../oauth_apis/oauthclient-oauth-openshift-io-v1.adoc#oauthclient-oauth-openshift-io-v1[`array (OAuthClient oauth.openshift.io/v1)`]
+| Items is the list of OAuth clients
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="oauthlist-config-openshift-io-v1"]
+== OAuthList [config.openshift.io/v1]
+
+
+Description::
++
+--
+OAuthList is a list of OAuth
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/oauth-config-openshift-io-v1.adoc#oauth-config-openshift-io-v1[`array (OAuth config.openshift.io/v1)`]
+| List of oauths. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="objectfieldselector-core-v1"]
+== ObjectFieldSelector [core/v1]
+
+
+Description::
++
+--
+ObjectFieldSelector selects an APIVersioned field of an object.
+--
+
+Type::
+  `object`
+
+Required::
+  - `fieldPath`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| Version of the schema the FieldPath is written in terms of, defaults to "v1".
+
+| `fieldPath`
+| `string`
+| Path of the field to select in the specified API version.
+
+|===
+
+[id="objectmeta-meta-v1"]
+== ObjectMeta [meta/v1]
+
+
+Description::
++
+--
+ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `annotations`
+| `object (string)`
+| Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+
+| `clusterName`
+| `string`
+| The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+
+| `creationTimestamp`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `deletionGracePeriodSeconds`
+| `integer`
+| Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+
+| `deletionTimestamp`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `finalizers`
+| `array (string)`
+| Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+
+| `generateName`
+| `string`
+| GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+| `generation`
+| `integer`
+| A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+
+| `labels`
+| `object (string)`
+| Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+
+| `managedFields`
+| xref:../objects/index.adoc#managedfieldsentry-meta-v1[`array (ManagedFieldsEntry meta/v1)`]
+| ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+| `name`
+| `string`
+| Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+| `namespace`
+| `string`
+| Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+
+| `ownerReferences`
+| xref:../objects/index.adoc#ownerreference-meta-v1[`array (OwnerReference meta/v1)`]
+| List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+
+| `resourceVersion`
+| `string`
+| An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+| `selfLink`
+| `string`
+| SelfLink is a URL representing this object. Populated by the system. Read-only.
+
+DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+
+| `uid`
+| `string`
+| UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+|===
+
+[id="objectmeta_v2-meta-v1"]
+== ObjectMeta_v2 [meta/v1]
+
+
+Description::
++
+--
+ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `annotations`
+| `object (string)`
+| Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+
+| `clusterName`
+| `string`
+| The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+
+| `creationTimestamp`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `deletionGracePeriodSeconds`
+| `integer`
+| Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+
+| `deletionTimestamp`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `finalizers`
+| `array (string)`
+| Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+
+| `generateName`
+| `string`
+| GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+| `generation`
+| `integer`
+| A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+
+| `labels`
+| `object (string)`
+| Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+
+| `managedFields`
+| xref:../objects/index.adoc#managedfieldsentry-meta-v1[`array (ManagedFieldsEntry meta/v1)`]
+| ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+| `name`
+| `string`
+| Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+| `namespace`
+| `string`
+| Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+
+| `ownerReferences`
+| xref:../objects/index.adoc#ownerreference_v2-meta-v1[`array (OwnerReference_v2 meta/v1)`]
+| List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+
+| `resourceVersion`
+| `string`
+| An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+| `selfLink`
+| `string`
+| SelfLink is a URL representing this object. Populated by the system. Read-only.
+
+DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+
+| `uid`
+| `string`
+| UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+|===
+
+[id="objectreference-core-v1"]
+== ObjectReference [core/v1]
+
+
+Description::
++
+--
+ObjectReference contains enough information to let you inspect or modify the referred object.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| API version of the referent.
+
+| `fieldPath`
+| `string`
+| If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.
+
+| `kind`
+| `string`
+| Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `namespace`
+| `string`
+| Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+
+| `resourceVersion`
+| `string`
+| Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+| `uid`
+| `string`
+| UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+
+|===
+
+[id="objectreference_v2-core-v1"]
+== ObjectReference_v2 [core/v1]
+
+
+Description::
++
+--
+ObjectReference contains enough information to let you inspect or modify the referred object.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| API version of the referent.
+
+| `fieldPath`
+| `string`
+| If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.
+
+| `kind`
+| `string`
+| Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `namespace`
+| `string`
+| Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+
+| `resourceVersion`
+| `string`
+| Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+| `uid`
+| `string`
+| UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+
+|===
+
+[id="openshiftapiserverlist-operator-openshift-io-v1"]
+== OpenShiftAPIServerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+OpenShiftAPIServerList is a list of OpenShiftAPIServer
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/openshiftapiserver-operator-openshift-io-v1.adoc#openshiftapiserver-operator-openshift-io-v1[`array (OpenShiftAPIServer operator.openshift.io/v1)`]
+| List of openshiftapiservers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="openshiftcontrollermanagerlist-operator-openshift-io-v1"]
+== OpenShiftControllerManagerList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+OpenShiftControllerManagerList is a list of OpenShiftControllerManager
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/openshiftcontrollermanager-operator-openshift-io-v1.adoc#openshiftcontrollermanager-operator-openshift-io-v1[`array (OpenShiftControllerManager operator.openshift.io/v1)`]
+| List of openshiftcontrollermanagers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="operatorconditionlist-operators-coreos-com-v2"]
+== OperatorConditionList [operators.coreos.com/v2]
+
+
+Description::
++
+--
+OperatorConditionList is a list of OperatorCondition
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/operatorcondition-operators-coreos-com-v2.adoc#operatorcondition-operators-coreos-com-v2[`array (OperatorCondition operators.coreos.com/v2)`]
+| List of operatorconditions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="operatorgrouplist-operators-coreos-com-v1"]
+== OperatorGroupList [operators.coreos.com/v1]
+
+
+Description::
++
+--
+OperatorGroupList is a list of OperatorGroup
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/operatorgroup-operators-coreos-com-v1.adoc#operatorgroup-operators-coreos-com-v1[`array (OperatorGroup operators.coreos.com/v1)`]
+| List of operatorgroups. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="operatorhublist-config-openshift-io-v1"]
+== OperatorHubList [config.openshift.io/v1]
+
+
+Description::
++
+--
+OperatorHubList is a list of OperatorHub
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/operatorhub-config-openshift-io-v1.adoc#operatorhub-config-openshift-io-v1[`array (OperatorHub config.openshift.io/v1)`]
+| List of operatorhubs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="operatorlist-operators-coreos-com-v1"]
+== OperatorList [operators.coreos.com/v1]
+
+
+Description::
++
+--
+OperatorList is a list of Operator
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/operator-operators-coreos-com-v1.adoc#operator-operators-coreos-com-v1[`array (Operator operators.coreos.com/v1)`]
+| List of operators. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="operatorpkilist-network-operator-openshift-io-v1"]
+== OperatorPKIList [network.operator.openshift.io/v1]
+
+
+Description::
++
+--
+OperatorPKIList is a list of OperatorPKI
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/operatorpki-network-operator-openshift-io-v1.adoc#operatorpki-network-operator-openshift-io-v1[`array (OperatorPKI network.operator.openshift.io/v1)`]
+| List of operatorpkis. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="ownerreference-meta-v1"]
+== OwnerReference [meta/v1]
+
+
+Description::
++
+--
+OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+--
+
+Type::
+  `object`
+
+Required::
+  - `apiVersion`
+  - `kind`
+  - `name`
+  - `uid`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| API version of the referent.
+
+| `blockOwnerDeletion`
+| `boolean`
+| If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+
+| `controller`
+| `boolean`
+| If true, this reference points to the managing controller.
+
+| `kind`
+| `string`
+| Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+| `uid`
+| `string`
+| UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+|===
+
+[id="ownerreference_v2-meta-v1"]
+== OwnerReference_v2 [meta/v1]
+
+
+Description::
++
+--
+OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+--
+
+Type::
+  `object`
+
+Required::
+  - `apiVersion`
+  - `kind`
+  - `name`
+  - `uid`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| API version of the referent.
+
+| `blockOwnerDeletion`
+| `boolean`
+| If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+
+| `controller`
+| `boolean`
+| If true, this reference points to the managing controller.
+
+| `kind`
+| `string`
+| Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+| `uid`
+| `string`
+| UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+|===
+
+[id="packagemanifestlist-packages-operators-coreos-com-v1"]
+== PackageManifestList [packages.operators.coreos.com/v1]
+
+
+Description::
++
+--
+PackageManifestList is a list of PackageManifest objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/packagemanifest-packages-operators-coreos-com-v1.adoc#packagemanifest-packages-operators-coreos-com-v1[`array (PackageManifest packages.operators.coreos.com/v1)`]
+| 
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="patch-meta-v1"]
+== Patch [meta/v1]
+
+
+Description::
++
+--
+Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.
+--
+
+Type::
+  `object`
+
+
+
+[id="persistentvolumeclaim-core-v1"]
+== PersistentVolumeClaim [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaim is a user's request for and claim to a persistent volume
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `spec`
+| `object`
+| PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+
+| `status`
+| `object`
+| PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+
+|===
+..spec
+Description::
++
+--
+PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+--
+
+Type::
+  `object`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `accessModes`
+| `array (string)`
+| AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+| `dataSource`
+| xref:../objects/index.adoc#typedlocalobjectreference-core-v1[`TypedLocalObjectReference core/v1`]
+| This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.
+
+| `dataSourceRef`
+| xref:../objects/index.adoc#typedlocalobjectreference-core-v1[`TypedLocalObjectReference core/v1`]
+| Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+  allows any non-core object, as well as PersistentVolumeClaim objects.
+* While DataSource ignores disallowed values (dropping them), DataSourceRef
+  preserves all values, and generates an error if a disallowed value is
+  specified.
+(Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+
+| `resources`
+| xref:../objects/index.adoc#resourcerequirements-core-v1[`ResourceRequirements core/v1`]
+| Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+
+| `selector`
+| xref:../objects/index.adoc#labelselector-meta-v1[`LabelSelector meta/v1`]
+| A label query over volumes to consider for binding.
+
+| `storageClassName`
+| `string`
+| Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+
+| `volumeMode`
+| `string`
+| volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+
+| `volumeName`
+| `string`
+| VolumeName is the binding reference to the PersistentVolume backing this claim.
+
+|===
+..status
+Description::
++
+--
+PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+--
+
+Type::
+  `object`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `accessModes`
+| `array (string)`
+| AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+| `capacity`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Represents the actual resources of the underlying volume.
+
+| `conditions`
+| xref:../objects/index.adoc#persistentvolumeclaimcondition-core-v1[`array (PersistentVolumeClaimCondition core/v1)`]
+| Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+
+| `phase`
+| `string`
+| Phase represents the current phase of PersistentVolumeClaim.
+
+|===
+
+[id="persistentvolumeclaimcondition-core-v1"]
+== PersistentVolumeClaimCondition [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaimCondition contails details about state of pvc
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastProbeTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time we probed the condition.
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time the condition transitioned from one status to another.
+
+| `message`
+| `string`
+| Human-readable message indicating details about last transition.
+
+| `reason`
+| `string`
+| Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+
+| `status`
+| `string`
+| 
+
+| `type`
+| `string`
+| 
+
+|===
+
+[id="persistentvolumeclaimlist-core-v1"]
+== PersistentVolumeClaimList [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/persistentvolumeclaim-core-v1.adoc#persistentvolumeclaim-core-v1[`array (PersistentVolumeClaim core/v1)`]
+| A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="persistentvolumeclaimspec-core-v1"]
+== PersistentVolumeClaimSpec [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `accessModes`
+| `array (string)`
+| AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+| `dataSource`
+| xref:../objects/index.adoc#typedlocalobjectreference-core-v1[`TypedLocalObjectReference core/v1`]
+| This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.
+
+| `dataSourceRef`
+| xref:../objects/index.adoc#typedlocalobjectreference-core-v1[`TypedLocalObjectReference core/v1`]
+| Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+  allows any non-core object, as well as PersistentVolumeClaim objects.
+* While DataSource ignores disallowed values (dropping them), DataSourceRef
+  preserves all values, and generates an error if a disallowed value is
+  specified.
+(Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+
+| `resources`
+| xref:../objects/index.adoc#resourcerequirements-core-v1[`ResourceRequirements core/v1`]
+| Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+
+| `selector`
+| xref:../objects/index.adoc#labelselector-meta-v1[`LabelSelector meta/v1`]
+| A label query over volumes to consider for binding.
+
+| `storageClassName`
+| `string`
+| Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+
+| `volumeMode`
+| `string`
+| volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+
+| `volumeName`
+| `string`
+| VolumeName is the binding reference to the PersistentVolume backing this claim.
+
+|===
+
+[id="persistentvolumeclaimtemplate-core-v1"]
+== PersistentVolumeClaimTemplate [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.
+--
+
+Type::
+  `object`
+
+Required::
+  - `spec`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+
+| `spec`
+| xref:../objects/index.adoc#persistentvolumeclaimspec-core-v1[`PersistentVolumeClaimSpec core/v1`]
+| The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+
+|===
+
+[id="persistentvolumeclaimvolumesource-core-v1"]
+== PersistentVolumeClaimVolumeSource [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+--
+
+Type::
+  `object`
+
+Required::
+  - `claimName`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `claimName`
+| `string`
+| ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| `readOnly`
+| `boolean`
+| Will force the ReadOnly setting in VolumeMounts. Default false.
+
+|===
+
+[id="persistentvolumelist-core-v1"]
+== PersistentVolumeList [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeList is a list of PersistentVolume items.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/persistentvolume-core-v1.adoc#persistentvolume-core-v1[`array (PersistentVolume core/v1)`]
+| List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="persistentvolumespec-core-v1"]
+== PersistentVolumeSpec [core/v1]
+
+
+Description::
++
+--
+PersistentVolumeSpec is the specification of a persistent volume.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `accessModes`
+| `array (string)`
+| AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
+
+| `awsElasticBlockStore`
+| xref:../objects/index.adoc#awselasticblockstorevolumesource-core-v1[`AWSElasticBlockStoreVolumeSource core/v1`]
+| AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| `azureDisk`
+| xref:../objects/index.adoc#azurediskvolumesource-core-v1[`AzureDiskVolumeSource core/v1`]
+| AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| `azureFile`
+| xref:../objects/index.adoc#azurefilepersistentvolumesource-core-v1[`AzureFilePersistentVolumeSource core/v1`]
+| AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| `capacity`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| A description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+
+| `cephfs`
+| xref:../objects/index.adoc#cephfspersistentvolumesource-core-v1[`CephFSPersistentVolumeSource core/v1`]
+| CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+
+| `cinder`
+| xref:../objects/index.adoc#cinderpersistentvolumesource-core-v1[`CinderPersistentVolumeSource core/v1`]
+| Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `claimRef`
+| xref:../objects/index.adoc#objectreference-core-v1[`ObjectReference core/v1`]
+| ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding
+
+| `csi`
+| xref:../objects/index.adoc#csipersistentvolumesource-core-v1[`CSIPersistentVolumeSource core/v1`]
+| CSI represents storage that is handled by an external CSI driver (Beta feature).
+
+| `fc`
+| xref:../objects/index.adoc#fcvolumesource-core-v1[`FCVolumeSource core/v1`]
+| FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+
+| `flexVolume`
+| xref:../objects/index.adoc#flexpersistentvolumesource-core-v1[`FlexPersistentVolumeSource core/v1`]
+| FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| `flocker`
+| xref:../objects/index.adoc#flockervolumesource-core-v1[`FlockerVolumeSource core/v1`]
+| Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
+
+| `gcePersistentDisk`
+| xref:../objects/index.adoc#gcepersistentdiskvolumesource-core-v1[`GCEPersistentDiskVolumeSource core/v1`]
+| GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| `glusterfs`
+| xref:../objects/index.adoc#glusterfspersistentvolumesource-core-v1[`GlusterfsPersistentVolumeSource core/v1`]
+| Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+
+| `hostPath`
+| xref:../objects/index.adoc#hostpathvolumesource-core-v1[`HostPathVolumeSource core/v1`]
+| HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| `iscsi`
+| xref:../objects/index.adoc#iscsipersistentvolumesource-core-v1[`ISCSIPersistentVolumeSource core/v1`]
+| ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
+
+| `local`
+| xref:../objects/index.adoc#localvolumesource-core-v1[`LocalVolumeSource core/v1`]
+| Local represents directly-attached storage with node affinity
+
+| `mountOptions`
+| `array (string)`
+| A list of mount options, e.g. ["ro", "soft"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options
+
+| `nfs`
+| xref:../objects/index.adoc#nfsvolumesource-core-v1[`NFSVolumeSource core/v1`]
+| NFS represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| `nodeAffinity`
+| xref:../objects/index.adoc#volumenodeaffinity-core-v1[`VolumeNodeAffinity core/v1`]
+| NodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
+
+| `persistentVolumeReclaimPolicy`
+| `string`
+| What happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+| `photonPersistentDisk`
+| xref:../objects/index.adoc#photonpersistentdiskvolumesource-core-v1[`PhotonPersistentDiskVolumeSource core/v1`]
+| PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+
+| `portworxVolume`
+| xref:../objects/index.adoc#portworxvolumesource-core-v1[`PortworxVolumeSource core/v1`]
+| PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+
+| `quobyte`
+| xref:../objects/index.adoc#quobytevolumesource-core-v1[`QuobyteVolumeSource core/v1`]
+| Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+
+| `rbd`
+| xref:../objects/index.adoc#rbdpersistentvolumesource-core-v1[`RBDPersistentVolumeSource core/v1`]
+| RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+
+| `scaleIO`
+| xref:../objects/index.adoc#scaleiopersistentvolumesource-core-v1[`ScaleIOPersistentVolumeSource core/v1`]
+| ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+
+| `storageClassName`
+| `string`
+| Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.
+
+| `storageos`
+| xref:../objects/index.adoc#storageospersistentvolumesource-core-v1[`StorageOSPersistentVolumeSource core/v1`]
+| StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://examples.k8s.io/volumes/storageos/README.md
+
+| `volumeMode`
+| `string`
+| volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+
+| `vsphereVolume`
+| xref:../objects/index.adoc#vspherevirtualdiskvolumesource-core-v1[`VsphereVirtualDiskVolumeSource core/v1`]
+| VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+
+|===
+
+[id="photonpersistentdiskvolumesource-core-v1"]
+== PhotonPersistentDiskVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Photon Controller persistent disk resource.
+--
+
+Type::
+  `object`
+
+Required::
+  - `pdID`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `pdID`
+| `string`
+| ID that identifies Photon Controller persistent disk
+
+|===
+
+[id="podaffinity-core-v1"]
+== PodAffinity [core/v1]
+
+
+Description::
++
+--
+Pod affinity is a group of inter pod affinity scheduling rules.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `preferredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#weightedpodaffinityterm-core-v1[`array (WeightedPodAffinityTerm core/v1)`]
+| The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+| `requiredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#podaffinityterm-core-v1[`array (PodAffinityTerm core/v1)`]
+| If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+|===
+
+[id="podaffinityterm-core-v1"]
+== PodAffinityTerm [core/v1]
+
+
+Description::
++
+--
+Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+--
+
+Type::
+  `object`
+
+Required::
+  - `topologyKey`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `labelSelector`
+| xref:../objects/index.adoc#labelselector-meta-v1[`LabelSelector meta/v1`]
+| A label query over a set of resources, in this case pods.
+
+| `namespaceSelector`
+| xref:../objects/index.adoc#labelselector-meta-v1[`LabelSelector meta/v1`]
+| A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+
+| `namespaces`
+| `array (string)`
+| namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+
+| `topologyKey`
+| `string`
+| This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+|===
+
+[id="podantiaffinity-core-v1"]
+== PodAntiAffinity [core/v1]
+
+
+Description::
++
+--
+Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `preferredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#weightedpodaffinityterm-core-v1[`array (WeightedPodAffinityTerm core/v1)`]
+| The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+| `requiredDuringSchedulingIgnoredDuringExecution`
+| xref:../objects/index.adoc#podaffinityterm-core-v1[`array (PodAffinityTerm core/v1)`]
+| If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+|===
+
+[id="podcondition-core-v1"]
+== PodCondition [core/v1]
+
+
+Description::
++
+--
+PodCondition contains details for the current condition of this pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastProbeTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time we probed the condition.
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| Last time the condition transitioned from one status to another.
+
+| `message`
+| `string`
+| Human-readable message indicating details about last transition.
+
+| `reason`
+| `string`
+| Unique, one-word, CamelCase reason for the condition's last transition.
+
+| `status`
+| `string`
+| Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+| `type`
+| `string`
+| Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+|===
+
+[id="poddisruptionbudgetlist-policy-v1"]
+== PodDisruptionBudgetList [policy/v1]
+
+
+Description::
++
+--
+PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../policy_apis/poddisruptionbudget-policy-v1.adoc#poddisruptionbudget-policy-v1[`array (PodDisruptionBudget policy/v1)`]
+| Items is a list of PodDisruptionBudgets
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="poddnsconfig-core-v1"]
+== PodDNSConfig [core/v1]
+
+
+Description::
++
+--
+PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `nameservers`
+| `array (string)`
+| A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+
+| `options`
+| xref:../objects/index.adoc#poddnsconfigoption-core-v1[`array (PodDNSConfigOption core/v1)`]
+| A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+
+| `searches`
+| `array (string)`
+| A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+
+|===
+
+[id="poddnsconfigoption-core-v1"]
+== PodDNSConfigOption [core/v1]
+
+
+Description::
++
+--
+PodDNSConfigOption defines DNS resolver options of a pod.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Required.
+
+| `value`
+| `string`
+| 
+
+|===
+
+[id="podip-core-v1"]
+== PodIP [core/v1]
+
+
+Description::
++
+--
+IP address information for entries in the (plural) PodIPs field. Each entry includes:
+   IP: An IP address allocated to the pod. Routable at least within the cluster.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `ip`
+| `string`
+| ip is an IP address (IPv4 or IPv6) assigned to the pod
+
+|===
+
+[id="podlist-core-v1"]
+== PodList [core/v1]
+
+
+Description::
++
+--
+PodList is a list of Pods.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/pod-core-v1.adoc#pod-core-v1[`array (Pod core/v1)`]
+| List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="podmonitorlist-monitoring-coreos-com-v1"]
+== PodMonitorList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+PodMonitorList is a list of PodMonitor
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc#podmonitor-monitoring-coreos-com-v1[`array (PodMonitor monitoring.coreos.com/v1)`]
+| List of podmonitors. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="podnetworkconnectivitychecklist-controlplane-operator-openshift-io-v1alpha1"]
+== PodNetworkConnectivityCheckList [controlplane.operator.openshift.io/v1alpha1]
+
+
+Description::
++
+--
+PodNetworkConnectivityCheckList is a list of PodNetworkConnectivityCheck
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/podnetworkconnectivitycheck-controlplane-operator-openshift-io-v1alpha1.adoc#podnetworkconnectivitycheck-controlplane-operator-openshift-io-v1alpha1[`array (PodNetworkConnectivityCheck controlplane.operator.openshift.io/v1alpha1)`]
+| List of podnetworkconnectivitychecks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="podreadinessgate-core-v1"]
+== PodReadinessGate [core/v1]
+
+
+Description::
++
+--
+PodReadinessGate contains the reference to a pod condition
+--
+
+Type::
+  `object`
+
+Required::
+  - `conditionType`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `conditionType`
+| `string`
+| ConditionType refers to a condition in the pod's condition list with matching type.
+
+|===
+
+[id="podsecuritycontext-core-v1"]
+== PodSecurityContext [core/v1]
+
+
+Description::
++
+--
+PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsGroup`
+| `integer`
+| A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+If unset, the Kubelet will not modify the ownership and permissions of any volume.
+
+| `fsGroupChangePolicy`
+| `string`
+| fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+
+| `runAsGroup`
+| `integer`
+| The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+| `runAsNonRoot`
+| `boolean`
+| Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+| `runAsUser`
+| `integer`
+| The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+| `seLinuxOptions`
+| xref:../objects/index.adoc#selinuxoptions-core-v1[`SELinuxOptions core/v1`]
+| The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+| `seccompProfile`
+| xref:../objects/index.adoc#seccompprofile-core-v1[`SeccompProfile core/v1`]
+| The seccomp options to use by the containers in this pod.
+
+| `supplementalGroups`
+| `array (integer)`
+| A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+
+| `sysctls`
+| xref:../objects/index.adoc#sysctl-core-v1[`array (Sysctl core/v1)`]
+| Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+
+| `windowsOptions`
+| xref:../objects/index.adoc#windowssecuritycontextoptions-core-v1[`WindowsSecurityContextOptions core/v1`]
+| The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+|===
+
+[id="podspec-core-v1"]
+== PodSpec [core/v1]
+
+
+Description::
++
+--
+PodSpec is a description of a pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `containers`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `activeDeadlineSeconds`
+| `integer`
+| Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+
+| `affinity`
+| xref:../objects/index.adoc#affinity-core-v1[`Affinity core/v1`]
+| If specified, the pod's scheduling constraints
+
+| `automountServiceAccountToken`
+| `boolean`
+| AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+
+| `containers`
+| xref:../objects/index.adoc#container-core-v1[`array (Container core/v1)`]
+| List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+
+| `dnsConfig`
+| xref:../objects/index.adoc#poddnsconfig-core-v1[`PodDNSConfig core/v1`]
+| Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+
+| `dnsPolicy`
+| `string`
+| Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+| `enableServiceLinks`
+| `boolean`
+| EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.
+
+| `ephemeralContainers`
+| xref:../objects/index.adoc#ephemeralcontainer-core-v1[`array (EphemeralContainer core/v1)`]
+| List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+
+| `hostAliases`
+| xref:../objects/index.adoc#hostalias-core-v1[`array (HostAlias core/v1)`]
+| HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
+
+| `hostIPC`
+| `boolean`
+| Use the host's ipc namespace. Optional: Default to false.
+
+| `hostNetwork`
+| `boolean`
+| Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+
+| `hostPID`
+| `boolean`
+| Use the host's pid namespace. Optional: Default to false.
+
+| `hostname`
+| `string`
+| Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+
+| `imagePullSecrets`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`array (LocalObjectReference core/v1)`]
+| ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+| `initContainers`
+| xref:../objects/index.adoc#container-core-v1[`array (Container core/v1)`]
+| List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+
+| `nodeName`
+| `string`
+| NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+
+| `nodeSelector`
+| `object (string)`
+| NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+
+| `overhead`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.
+
+| `preemptionPolicy`
+| `string`
+| PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+
+| `priority`
+| `integer`
+| The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+
+| `priorityClassName`
+| `string`
+| If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+
+| `readinessGates`
+| xref:../objects/index.adoc#podreadinessgate-core-v1[`array (PodReadinessGate core/v1)`]
+| If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+
+| `restartPolicy`
+| `string`
+| Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+| `runtimeClassName`
+| `string`
+| RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.
+
+| `schedulerName`
+| `string`
+| If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+
+| `securityContext`
+| xref:../objects/index.adoc#podsecuritycontext-core-v1[`PodSecurityContext core/v1`]
+| SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
+
+| `serviceAccount`
+| `string`
+| DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.
+
+| `serviceAccountName`
+| `string`
+| ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+
+| `setHostnameAsFQDN`
+| `boolean`
+| If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+
+| `shareProcessNamespace`
+| `boolean`
+| Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.
+
+| `subdomain`
+| `string`
+| If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+
+| `terminationGracePeriodSeconds`
+| `integer`
+| Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+
+| `tolerations`
+| xref:../objects/index.adoc#toleration-core-v1[`array (Toleration core/v1)`]
+| If specified, the pod's tolerations.
+
+| `topologySpreadConstraints`
+| xref:../objects/index.adoc#topologyspreadconstraint-core-v1[`array (TopologySpreadConstraint core/v1)`]
+| TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+
+| `volumes`
+| xref:../objects/index.adoc#volume-core-v1[`array (Volume core/v1)`]
+| List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+
+|===
+
+[id="podtemplatelist-core-v1"]
+== PodTemplateList [core/v1]
+
+
+Description::
++
+--
+PodTemplateList is a list of PodTemplates.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../template_apis/podtemplate-core-v1.adoc#podtemplate-core-v1[`array (PodTemplate core/v1)`]
+| List of pod templates
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="podtemplatespec-core-v1"]
+== PodTemplateSpec [core/v1]
+
+
+Description::
++
+--
+PodTemplateSpec describes the data a pod should have when created from a template
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `spec`
+| xref:../objects/index.adoc#podspec-core-v1[`PodSpec core/v1`]
+| Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+|===
+
+[id="portstatus-core-v1"]
+== PortStatus [core/v1]
+
+
+Description::
++
+--
+
+--
+
+Type::
+  `object`
+
+Required::
+  - `port`
+  - `protocol`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `error`
+| `string`
+| Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+  CamelCase names
+- cloud provider specific error values must have names that comply with the
+  format foo.example.com/CamelCase.
+
+| `port`
+| `integer`
+| Port is the port number of the service port of which status is recorded here
+
+| `protocol`
+| `string`
+| Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+|===
+
+[id="portworxvolumesource-core-v1"]
+== PortworxVolumeSource [core/v1]
+
+
+Description::
++
+--
+PortworxVolumeSource represents a Portworx volume resource.
+--
+
+Type::
+  `object`
+
+Required::
+  - `volumeID`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `volumeID`
+| `string`
+| VolumeID uniquely identifies a Portworx volume
+
+|===
+
+[id="preferredschedulingterm-core-v1"]
+== PreferredSchedulingTerm [core/v1]
+
+
+Description::
++
+--
+An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+--
+
+Type::
+  `object`
+
+Required::
+  - `weight`
+  - `preference`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `preference`
+| xref:../objects/index.adoc#nodeselectorterm-core-v1[`NodeSelectorTerm core/v1`]
+| A node selector term, associated with the corresponding weight.
+
+| `weight`
+| `integer`
+| Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+|===
+
+[id="priorityclasslist-scheduling-k8s-io-v1"]
+== PriorityClassList [scheduling.k8s.io/v1]
+
+
+Description::
++
+--
+PriorityClassList is a collection of priority classes.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/priorityclass-scheduling-k8s-io-v1.adoc#priorityclass-scheduling-k8s-io-v1[`array (PriorityClass scheduling.k8s.io/v1)`]
+| items is the list of PriorityClasses
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="prioritylevelconfigurationlist-flowcontrol-apiserver-k8s-io-v1beta1"]
+== PriorityLevelConfigurationList [flowcontrol.apiserver.k8s.io/v1beta1]
+
+
+Description::
++
+--
+PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1beta1.adoc#prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1beta1[`array (PriorityLevelConfiguration flowcontrol.apiserver.k8s.io/v1beta1)`]
+| `items` is a list of request-priorities.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="probe-core-v1"]
+== Probe [core/v1]
+
+
+Description::
++
+--
+Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `exec`
+| xref:../objects/index.adoc#execaction-core-v1[`ExecAction core/v1`]
+| One and only one of the following should be specified. Exec specifies the action to take.
+
+| `failureThreshold`
+| `integer`
+| Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+| `httpGet`
+| xref:../objects/index.adoc#httpgetaction-core-v1[`HTTPGetAction core/v1`]
+| HTTPGet specifies the http request to perform.
+
+| `initialDelaySeconds`
+| `integer`
+| Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+| `periodSeconds`
+| `integer`
+| How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+| `successThreshold`
+| `integer`
+| Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+| `tcpSocket`
+| xref:../objects/index.adoc#tcpsocketaction-core-v1[`TCPSocketAction core/v1`]
+| TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+| `terminationGracePeriodSeconds`
+| `integer`
+| Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+
+| `timeoutSeconds`
+| `integer`
+| Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+|===
+
+[id="probelist-monitoring-coreos-com-v1"]
+== ProbeList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+ProbeList is a list of Probe
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/probe-monitoring-coreos-com-v1.adoc#probe-monitoring-coreos-com-v1[`array (Probe monitoring.coreos.com/v1)`]
+| List of probes. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="profilelist-tuned-openshift-io-v1"]
+== ProfileList [tuned.openshift.io/v1]
+
+
+Description::
++
+--
+ProfileList is a list of Profile
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../node_apis/profile-tuned-openshift-io-v1.adoc#profile-tuned-openshift-io-v1[`array (Profile tuned.openshift.io/v1)`]
+| List of profiles. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="projectedvolumesource-core-v1"]
+== ProjectedVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a projected volume source
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `defaultMode`
+| `integer`
+| Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `sources`
+| xref:../objects/index.adoc#volumeprojection-core-v1[`array (VolumeProjection core/v1)`]
+| list of volume projections
+
+|===
+
+[id="projectlist-config-openshift-io-v1"]
+== ProjectList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ProjectList is a list of Project
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/project-config-openshift-io-v1.adoc#project-config-openshift-io-v1[`array (Project config.openshift.io/v1)`]
+| List of projects. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="projectlist-project-openshift-io-v1"]
+== ProjectList [project.openshift.io/v1]
+
+
+Description::
++
+--
+ProjectList is a list of Project objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../project_apis/project-project-openshift-io-v1.adoc#project-project-openshift-io-v1[`array (Project project.openshift.io/v1)`]
+| Items is the list of projects
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="prometheuslist-monitoring-coreos-com-v1"]
+== PrometheusList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+PrometheusList is a list of Prometheus
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#prometheus-monitoring-coreos-com-v1[`array (Prometheus monitoring.coreos.com/v1)`]
+| List of prometheuses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="prometheusrulelist-monitoring-coreos-com-v1"]
+== PrometheusRuleList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+PrometheusRuleList is a list of PrometheusRule
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/prometheusrule-monitoring-coreos-com-v1.adoc#prometheusrule-monitoring-coreos-com-v1[`array (PrometheusRule monitoring.coreos.com/v1)`]
+| List of prometheusrules. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="provisioninglist-metal3-io-v1alpha1"]
+== ProvisioningList [metal3.io/v1alpha1]
+
+
+Description::
++
+--
+ProvisioningList is a list of Provisioning
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../provisioning_apis/provisioning-metal3-io-v1alpha1.adoc#provisioning-metal3-io-v1alpha1[`array (Provisioning metal3.io/v1alpha1)`]
+| List of provisionings. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="proxylist-config-openshift-io-v1"]
+== ProxyList [config.openshift.io/v1]
+
+
+Description::
++
+--
+ProxyList is a list of Proxy
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/proxy-config-openshift-io-v1.adoc#proxy-config-openshift-io-v1[`array (Proxy config.openshift.io/v1)`]
+| List of proxies. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="quantity-api-none"]
+== Quantity [api/none]
+
+
+Description::
++
+--
+Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+The serialization format is:
+
+<quantity>        ::= <signedNumber><suffix>
+  (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+<decimalSI>       ::= m | "" | k | M | G | T | P | E
+  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+<decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+  a. No precision is lost
+  b. No fractional digits will be emitted
+  c. The exponent (or suffix) is as large as possible.
+The sign will be omitted unless the number is negative.
+
+Examples:
+  1.5 will be serialized as "1500m"
+  1.5Gi will be serialized as "1536Mi"
+
+Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+--
+
+Type::
+  `string`
+
+
+
+[id="quobytevolumesource-core-v1"]
+== QuobyteVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `registry`
+  - `volume`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `group`
+| `string`
+| Group to map volume access to Default is no group
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+| `registry`
+| `string`
+| Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+| `tenant`
+| `string`
+| Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+| `user`
+| `string`
+| User to map volume access to Defaults to serivceaccount user
+
+| `volume`
+| `string`
+| Volume is a string that references an already created Quobyte volume by name.
+
+|===
+
+[id="rangeallocationlist-security-openshift-io-v1"]
+== RangeAllocationList [security.openshift.io/v1]
+
+
+Description::
++
+--
+RangeAllocationList is a list of RangeAllocations objects
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/rangeallocation-security-openshift-io-v1.adoc#rangeallocation-security-openshift-io-v1[`array (RangeAllocation security.openshift.io/v1)`]
+| List of RangeAllocations.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="rawextension-pkg-none"]
+== RawExtension [pkg/none]
+
+
+Description::
++
+--
+RawExtension is used to hold extensions in external versions.
+
+To use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.
+
+// Internal package: type MyAPIObject struct {
+	runtime.TypeMeta `json:",inline"`
+	MyPlugin runtime.Object `json:"myPlugin"`
+} type PluginA struct {
+	AOption string `json:"aOption"`
+}
+
+// External package: type MyAPIObject struct {
+	runtime.TypeMeta `json:",inline"`
+	MyPlugin runtime.RawExtension `json:"myPlugin"`
+} type PluginA struct {
+	AOption string `json:"aOption"`
+}
+
+// On the wire, the JSON will look something like this: {
+	"kind":"MyAPIObject",
+	"apiVersion":"v1",
+	"myPlugin": {
+		"kind":"PluginA",
+		"aOption":"foo",
+	},
+}
+
+So what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)
+--
+
+Type::
+  `object`
+
+
+
+[id="rbdpersistentvolumesource-core-v1"]
+== RBDPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `monitors`
+  - `image`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| `image`
+| `string`
+| The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `keyring`
+| `string`
+| Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `monitors`
+| `array (string)`
+| A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `pool`
+| `string`
+| The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `user`
+| `string`
+| The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+|===
+
+[id="rbdvolumesource-core-v1"]
+== RBDVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+Required::
+  - `monitors`
+  - `image`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| `image`
+| `string`
+| The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `keyring`
+| `string`
+| Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `monitors`
+| `array (string)`
+| A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `pool`
+| `string`
+| The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `readOnly`
+| `boolean`
+| ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| `user`
+| `string`
+| The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+|===
+
+[id="replicasetlist-apps-v1"]
+== ReplicaSetList [apps/v1]
+
+
+Description::
++
+--
+ReplicaSetList is a collection of ReplicaSets.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/replicaset-apps-v1.adoc#replicaset-apps-v1[`array (ReplicaSet apps/v1)`]
+| List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="replicationcontrollercondition-core-v1"]
+== ReplicationControllerCondition [core/v1]
+
+
+Description::
++
+--
+ReplicationControllerCondition describes the state of a replication controller at a certain point.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+  - `status`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `lastTransitionTime`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| The last time the condition transitioned from one status to another.
+
+| `message`
+| `string`
+| A human readable message indicating details about the transition.
+
+| `reason`
+| `string`
+| The reason for the condition's last transition.
+
+| `status`
+| `string`
+| Status of the condition, one of True, False, Unknown.
+
+| `type`
+| `string`
+| Type of replication controller condition.
+
+|===
+
+[id="replicationcontrollerlist-core-v1"]
+== ReplicationControllerList [core/v1]
+
+
+Description::
++
+--
+ReplicationControllerList is a collection of replication controllers.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/replicationcontroller-core-v1.adoc#replicationcontroller-core-v1[`array (ReplicationController core/v1)`]
+| List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="resourcefieldselector-core-v1"]
+== ResourceFieldSelector [core/v1]
+
+
+Description::
++
+--
+ResourceFieldSelector represents container resources (cpu, memory) and their output format
+--
+
+Type::
+  `object`
+
+Required::
+  - `resource`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `containerName`
+| `string`
+| Container name: required for volumes, optional for env vars
+
+| `divisor`
+| xref:../objects/index.adoc#quantity-api-none[`Quantity api/none`]
+| Specifies the output format of the exposed resources, defaults to "1"
+
+| `resource`
+| `string`
+| Required: resource to select
+
+|===
+
+[id="resourcequotalist-core-v1"]
+== ResourceQuotaList [core/v1]
+
+
+Description::
++
+--
+ResourceQuotaList is a list of ResourceQuota items.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../schedule_and_quota_apis/resourcequota-core-v1.adoc#resourcequota-core-v1[`array (ResourceQuota core/v1)`]
+| Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="resourcequotaspec-core-v1"]
+== ResourceQuotaSpec [core/v1]
+
+
+Description::
++
+--
+ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `hard`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+| `scopeSelector`
+| xref:../objects/index.adoc#scopeselector-core-v1[`ScopeSelector core/v1`]
+| scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+
+| `scopes`
+| `array (string)`
+| A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+
+|===
+
+[id="resourcequotastatus-core-v1"]
+== ResourceQuotaStatus [core/v1]
+
+
+Description::
++
+--
+ResourceQuotaStatus defines the enforced hard limits and observed use.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `hard`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+| `used`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Used is the current observed total usage of the resource in the namespace.
+
+|===
+
+[id="resourcerequirements-core-v1"]
+== ResourceRequirements [core/v1]
+
+
+Description::
++
+--
+ResourceRequirements describes the compute resource requirements.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `limits`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `requests`
+| xref:../objects/index.adoc#quantity-api-none[`object (Quantity api/none)`]
+| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+
+[id="rolebindinglist-authorization-openshift-io-v1"]
+== RoleBindingList [authorization.openshift.io/v1]
+
+
+Description::
++
+--
+RoleBindingList is a collection of RoleBindings
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../role_apis/rolebinding-authorization-openshift-io-v1.adoc#rolebinding-authorization-openshift-io-v1[`array (RoleBinding authorization.openshift.io/v1)`]
+| Items is a list of RoleBindings
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="rolebindinglist-rbac-authorization-k8s-io-v1"]
+== RoleBindingList [rbac.authorization.k8s.io/v1]
+
+
+Description::
++
+--
+RoleBindingList is a collection of RoleBindings
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../rbac_apis/rolebinding-rbac-authorization-k8s-io-v1.adoc#rolebinding-rbac-authorization-k8s-io-v1[`array (RoleBinding rbac.authorization.k8s.io/v1)`]
+| Items is a list of RoleBindings
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata.
+
+|===
+
+[id="rolebindingrestrictionlist-authorization-openshift-io-v1"]
+== RoleBindingRestrictionList [authorization.openshift.io/v1]
+
+
+Description::
++
+--
+RoleBindingRestrictionList is a list of RoleBindingRestriction
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../role_apis/rolebindingrestriction-authorization-openshift-io-v1.adoc#rolebindingrestriction-authorization-openshift-io-v1[`array (RoleBindingRestriction authorization.openshift.io/v1)`]
+| List of rolebindingrestrictions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="rolelist-authorization-openshift-io-v1"]
+== RoleList [authorization.openshift.io/v1]
+
+
+Description::
++
+--
+RoleList is a collection of Roles
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../role_apis/role-authorization-openshift-io-v1.adoc#role-authorization-openshift-io-v1[`array (Role authorization.openshift.io/v1)`]
+| Items is a list of Roles
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="rolelist-rbac-authorization-k8s-io-v1"]
+== RoleList [rbac.authorization.k8s.io/v1]
+
+
+Description::
++
+--
+RoleList is a collection of Roles
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../rbac_apis/role-rbac-authorization-k8s-io-v1.adoc#role-rbac-authorization-k8s-io-v1[`array (Role rbac.authorization.k8s.io/v1)`]
+| Items is a list of Roles
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard object's metadata.
+
+|===
+
+[id="routelist-route-openshift-io-v1"]
+== RouteList [route.openshift.io/v1]
+
+
+Description::
++
+--
+RouteList is a collection of Routes.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/route-route-openshift-io-v1.adoc#route-route-openshift-io-v1[`array (Route route.openshift.io/v1)`]
+| items is a list of routes
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="runtimeclasslist-node-k8s-io-v1"]
+== RuntimeClassList [node.k8s.io/v1]
+
+
+Description::
++
+--
+RuntimeClassList is a list of RuntimeClass objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../node_apis/runtimeclass-node-k8s-io-v1.adoc#runtimeclass-node-k8s-io-v1[`array (RuntimeClass node.k8s.io/v1)`]
+| Items is a list of schema objects.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="scale-autoscaling-v1"]
+== Scale [autoscaling/v1]
+
+
+Description::
++
+--
+Scale represents a scaling request for a resource.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+
+| `spec`
+| xref:../objects/index.adoc#scalespec-autoscaling-v1[`ScaleSpec autoscaling/v1`]
+| defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+
+| `status`
+| xref:../objects/index.adoc#scalestatus-autoscaling-v1[`ScaleStatus autoscaling/v1`]
+| current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+
+|===
+
+[id="scale-extensions-v1beta1"]
+== Scale [extensions/v1beta1]
+
+
+Description::
++
+--
+represents a scaling request for a resource.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+
+| `spec`
+| xref:../objects/index.adoc#scalespec-extensions-v1beta1[`ScaleSpec extensions/v1beta1`]
+| defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+
+| `status`
+| xref:../objects/index.adoc#scalestatus-extensions-v1beta1[`ScaleStatus extensions/v1beta1`]
+| current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+
+|===
+
+[id="scale_v2-autoscaling-v1"]
+== Scale_v2 [autoscaling/v1]
+
+
+Description::
++
+--
+Scale represents a scaling request for a resource.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta_v2-meta-v1[`ObjectMeta_v2 meta/v1`]
+| Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+
+| `spec`
+| xref:../objects/index.adoc#scalespec-autoscaling-v1[`ScaleSpec autoscaling/v1`]
+| defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+
+| `status`
+| xref:../objects/index.adoc#scalestatus-autoscaling-v1[`ScaleStatus autoscaling/v1`]
+| current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+
+|===
+
+[id="scaleiopersistentvolumesource-core-v1"]
+== ScaleIOPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
+--
+
+Type::
+  `object`
+
+Required::
+  - `gateway`
+  - `system`
+  - `secretRef`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+
+| `gateway`
+| `string`
+| The host address of the ScaleIO API Gateway.
+
+| `protectionDomain`
+| `string`
+| The name of the ScaleIO Protection Domain for the configured storage.
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#secretreference-core-v1[`SecretReference core/v1`]
+| SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+
+| `sslEnabled`
+| `boolean`
+| Flag to enable/disable SSL communication with Gateway, default false
+
+| `storageMode`
+| `string`
+| Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| `storagePool`
+| `string`
+| The ScaleIO Storage Pool associated with the protection domain.
+
+| `system`
+| `string`
+| The name of the storage system as configured in ScaleIO.
+
+| `volumeName`
+| `string`
+| The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+|===
+
+[id="scaleiovolumesource-core-v1"]
+== ScaleIOVolumeSource [core/v1]
+
+
+Description::
++
+--
+ScaleIOVolumeSource represents a persistent ScaleIO volume
+--
+
+Type::
+  `object`
+
+Required::
+  - `gateway`
+  - `system`
+  - `secretRef`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+| `gateway`
+| `string`
+| The host address of the ScaleIO API Gateway.
+
+| `protectionDomain`
+| `string`
+| The name of the ScaleIO Protection Domain for the configured storage.
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+
+| `sslEnabled`
+| `boolean`
+| Flag to enable/disable SSL communication with Gateway, default false
+
+| `storageMode`
+| `string`
+| Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| `storagePool`
+| `string`
+| The ScaleIO Storage Pool associated with the protection domain.
+
+| `system`
+| `string`
+| The name of the storage system as configured in ScaleIO.
+
+| `volumeName`
+| `string`
+| The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+|===
+
+[id="schedulerlist-config-openshift-io-v1"]
+== SchedulerList [config.openshift.io/v1]
+
+
+Description::
++
+--
+SchedulerList is a list of Scheduler
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../config_apis/scheduler-config-openshift-io-v1.adoc#scheduler-config-openshift-io-v1[`array (Scheduler config.openshift.io/v1)`]
+| List of schedulers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="scopedresourceselectorrequirement-core-v1"]
+== ScopedResourceSelectorRequirement [core/v1]
+
+
+Description::
++
+--
+A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+--
+
+Type::
+  `object`
+
+Required::
+  - `scopeName`
+  - `operator`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `operator`
+| `string`
+| Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+
+| `scopeName`
+| `string`
+| The name of the scope that the selector applies to.
+
+| `values`
+| `array (string)`
+| An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+|===
+
+[id="scopeselector-core-v1"]
+== ScopeSelector [core/v1]
+
+
+Description::
++
+--
+A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `matchExpressions`
+| xref:../objects/index.adoc#scopedresourceselectorrequirement-core-v1[`array (ScopedResourceSelectorRequirement core/v1)`]
+| A list of scope selector requirements by scope of the resources.
+
+|===
+
+[id="seccompprofile-core-v1"]
+== SeccompProfile [core/v1]
+
+
+Description::
++
+--
+SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.
+--
+
+Type::
+  `object`
+
+Required::
+  - `type`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `localhostProfile`
+| `string`
+| localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+
+| `type`
+| `string`
+| type indicates which kind of seccomp profile will be applied. Valid options are:
+
+Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+|===
+
+[id="secretenvsource-core-v1"]
+== SecretEnvSource [core/v1]
+
+
+Description::
++
+--
+SecretEnvSource selects a Secret to populate the environment variables with.
+
+The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the Secret must be defined
+
+|===
+
+[id="secretkeyselector-core-v1"]
+== SecretKeySelector [core/v1]
+
+
+Description::
++
+--
+SecretKeySelector selects a key of a Secret.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| The key of the secret to select from.  Must be a valid secret key.
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the Secret or its key must be defined
+
+|===
+
+[id="secretlist-core-v1"]
+== SecretList [core/v1]
+
+
+Description::
++
+--
+SecretList is a list of Secret.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/secret-core-v1.adoc#secret-core-v1[`array (Secret core/v1)`]
+| Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="secretlist-image-openshift-io-v1"]
+== SecretList [image.openshift.io/v1]
+
+
+Description::
++
+--
+SecretList is a list of Secret.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/secret-core-v1.adoc#secret-core-v1[`array (Secret core/v1)`]
+| Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="secretprojection-core-v1"]
+== SecretProjection [core/v1]
+
+
+Description::
++
+--
+Adapts a secret into a projected volume.
+
+The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `items`
+| xref:../objects/index.adoc#keytopath-core-v1[`array (KeyToPath core/v1)`]
+| If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| `name`
+| `string`
+| Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `optional`
+| `boolean`
+| Specify whether the Secret or its key must be defined
+
+|===
+
+[id="secretreference-core-v1"]
+== SecretReference [core/v1]
+
+
+Description::
++
+--
+SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name is unique within a namespace to reference a secret resource.
+
+| `namespace`
+| `string`
+| Namespace defines the space within which the secret name must be unique.
+
+|===
+
+[id="secretvolumesource-core-v1"]
+== SecretVolumeSource [core/v1]
+
+
+Description::
++
+--
+Adapts a Secret into a volume.
+
+The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `defaultMode`
+| `integer`
+| Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| `items`
+| xref:../objects/index.adoc#keytopath-core-v1[`array (KeyToPath core/v1)`]
+| If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| `optional`
+| `boolean`
+| Specify whether the Secret or its keys must be defined
+
+| `secretName`
+| `string`
+| Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+|===
+
+[id="securitycontext-core-v1"]
+== SecurityContext [core/v1]
+
+
+Description::
++
+--
+SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `allowPrivilegeEscalation`
+| `boolean`
+| AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+
+| `capabilities`
+| xref:../objects/index.adoc#capabilities-core-v1[`Capabilities core/v1`]
+| The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+
+| `privileged`
+| `boolean`
+| Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+
+| `procMount`
+| `string`
+| procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+
+| `readOnlyRootFilesystem`
+| `boolean`
+| Whether this container has a read-only root filesystem. Default is false.
+
+| `runAsGroup`
+| `integer`
+| The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+| `runAsNonRoot`
+| `boolean`
+| Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+| `runAsUser`
+| `integer`
+| The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+| `seLinuxOptions`
+| xref:../objects/index.adoc#selinuxoptions-core-v1[`SELinuxOptions core/v1`]
+| The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+| `seccompProfile`
+| xref:../objects/index.adoc#seccompprofile-core-v1[`SeccompProfile core/v1`]
+| The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+
+| `windowsOptions`
+| xref:../objects/index.adoc#windowssecuritycontextoptions-core-v1[`WindowsSecurityContextOptions core/v1`]
+| The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+|===
+
+[id="securitycontextconstraintslist-security-openshift-io-v1"]
+== SecurityContextConstraintsList [security.openshift.io/v1]
+
+
+Description::
++
+--
+SecurityContextConstraintsList is a list of SecurityContextConstraints
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[`array (SecurityContextConstraints security.openshift.io/v1)`]
+| List of securitycontextconstraints. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="selinuxoptions-core-v1"]
+== SELinuxOptions [core/v1]
+
+
+Description::
++
+--
+SELinuxOptions are the labels to be applied to the container
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `level`
+| `string`
+| Level is SELinux level label that applies to the container.
+
+| `role`
+| `string`
+| Role is a SELinux role label that applies to the container.
+
+| `type`
+| `string`
+| Type is a SELinux type label that applies to the container.
+
+| `user`
+| `string`
+| User is a SELinux user label that applies to the container.
+
+|===
+
+[id="serviceaccountlist-core-v1"]
+== ServiceAccountList [core/v1]
+
+
+Description::
++
+--
+ServiceAccountList is a list of ServiceAccount objects
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../security_apis/serviceaccount-core-v1.adoc#serviceaccount-core-v1[`array (ServiceAccount core/v1)`]
+| List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="serviceaccounttokenprojection-core-v1"]
+== ServiceAccountTokenProjection [core/v1]
+
+
+Description::
++
+--
+ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+--
+
+Type::
+  `object`
+
+Required::
+  - `path`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `audience`
+| `string`
+| Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+
+| `expirationSeconds`
+| `integer`
+| ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+
+| `path`
+| `string`
+| Path is the path relative to the mount point of the file to project the token into.
+
+|===
+
+[id="servicecalist-operator-openshift-io-v1"]
+== ServiceCAList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+ServiceCAList is a list of ServiceCA
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/serviceca-operator-openshift-io-v1.adoc#serviceca-operator-openshift-io-v1[`array (ServiceCA operator.openshift.io/v1)`]
+| List of servicecas. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="servicelist-core-v1"]
+== ServiceList [core/v1]
+
+
+Description::
++
+--
+ServiceList holds a list of services.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../network_apis/service-core-v1.adoc#service-core-v1[`array (Service core/v1)`]
+| List of services
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="servicemonitorlist-monitoring-coreos-com-v1"]
+== ServiceMonitorList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+ServiceMonitorList is a list of ServiceMonitor
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc#servicemonitor-monitoring-coreos-com-v1[`array (ServiceMonitor monitoring.coreos.com/v1)`]
+| List of servicemonitors. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="serviceport-core-v1"]
+== ServicePort [core/v1]
+
+
+Description::
++
+--
+ServicePort contains information on service's port.
+--
+
+Type::
+  `object`
+
+Required::
+  - `port`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `appProtocol`
+| `string`
+| The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+
+| `name`
+| `string`
+| The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+
+| `nodePort`
+| `integer`
+| The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+| `port`
+| `integer`
+| The port that will be exposed by this service.
+
+| `protocol`
+| `string`
+| The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+| `targetPort`
+| xref:../objects/index.adoc#intorstring-util-none[`IntOrString util/none`]
+| Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+
+|===
+
+[id="sessionaffinityconfig-core-v1"]
+== SessionAffinityConfig [core/v1]
+
+
+Description::
++
+--
+SessionAffinityConfig represents the configurations of session affinity.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `clientIP`
+| xref:../objects/index.adoc#clientipconfig-core-v1[`ClientIPConfig core/v1`]
+| clientIP contains the configurations of Client IP based session affinity.
+
+|===
+
+[id="statefulsetlist-apps-v1"]
+== StatefulSetList [apps/v1]
+
+
+Description::
++
+--
+StatefulSetList is a collection of StatefulSets.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../workloads_apis/statefulset-apps-v1.adoc#statefulset-apps-v1[`array (StatefulSet apps/v1)`]
+| Items is the list of stateful sets.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="status-meta-v1"]
+== Status [meta/v1]
+
+
+Description::
++
+--
+Status is a return value for calls that don't return other objects.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `code`
+| `integer`
+| Suggested HTTP return code for this status, 0 if not set.
+
+| `details`
+| xref:../objects/index.adoc#statusdetails-meta-v1[`StatusDetails meta/v1`]
+| Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `message`
+| `string`
+| A human-readable description of the status of this operation.
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `reason`
+| `string`
+| A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+
+| `status`
+| `string`
+| Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+|===
+
+[id="status_v2-meta-v1"]
+== Status_v2 [meta/v1]
+
+
+Description::
++
+--
+Status is a return value for calls that don't return other objects.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `code`
+| `integer`
+| Suggested HTTP return code for this status, 0 if not set.
+
+| `details`
+| xref:../objects/index.adoc#statusdetails_v2-meta-v1[`StatusDetails_v2 meta/v1`]
+| Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `message`
+| `string`
+| A human-readable description of the status of this operation.
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `reason`
+| `string`
+| A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+
+| `status`
+| `string`
+| Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+|===
+
+[id="statuscause-meta-v1"]
+== StatusCause [meta/v1]
+
+
+Description::
++
+--
+StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `field`
+| `string`
+| The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+Examples:
+  "name" - the field "name" on the current resource
+  "items[0].name" - the field "name" on the first array entry in "items"
+
+| `message`
+| `string`
+| A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+
+| `reason`
+| `string`
+| A machine-readable description of the cause of the error. If this value is empty there is no information available.
+
+|===
+
+[id="statusdetails-meta-v1"]
+== StatusDetails [meta/v1]
+
+
+Description::
++
+--
+StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `causes`
+| xref:../objects/index.adoc#statuscause-meta-v1[`array (StatusCause meta/v1)`]
+| The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+
+| `group`
+| `string`
+| The group attribute of the resource associated with the status StatusReason.
+
+| `kind`
+| `string`
+| The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `name`
+| `string`
+| The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+
+| `retryAfterSeconds`
+| `integer`
+| If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+
+| `uid`
+| `string`
+| UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+|===
+
+[id="storageclasslist-storage-k8s-io-v1"]
+== StorageClassList [storage.k8s.io/v1]
+
+
+Description::
++
+--
+StorageClassList is a collection of storage classes.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/storageclass-storage-k8s-io-v1.adoc#storageclass-storage-k8s-io-v1[`array (StorageClass storage.k8s.io/v1)`]
+| Items is the list of StorageClasses
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="storagelist-operator-openshift-io-v1"]
+== StorageList [operator.openshift.io/v1]
+
+
+Description::
++
+--
+StorageList is a list of Storage
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operator_apis/storage-operator-openshift-io-v1.adoc#storage-operator-openshift-io-v1[`array (Storage operator.openshift.io/v1)`]
+| List of storages. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="storageospersistentvolumesource-core-v1"]
+== StorageOSPersistentVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a StorageOS persistent volume resource.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#objectreference-core-v1[`ObjectReference core/v1`]
+| SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+
+| `volumeName`
+| `string`
+| VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| `volumeNamespace`
+| `string`
+| VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+|===
+
+[id="storageosvolumesource-core-v1"]
+== StorageOSVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a StorageOS persistent volume resource.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `readOnly`
+| `boolean`
+| Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| `secretRef`
+| xref:../objects/index.adoc#localobjectreference-core-v1[`LocalObjectReference core/v1`]
+| SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+
+| `volumeName`
+| `string`
+| VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| `volumeNamespace`
+| `string`
+| VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+|===
+
+[id="storagestatelist-migration-k8s-io-v1alpha1"]
+== StorageStateList [migration.k8s.io/v1alpha1]
+
+
+Description::
++
+--
+StorageStateList is a list of StorageState
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/storagestate-migration-k8s-io-v1alpha1.adoc#storagestate-migration-k8s-io-v1alpha1[`array (StorageState migration.k8s.io/v1alpha1)`]
+| List of storagestates. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="storageversionmigrationlist-migration-k8s-io-v1alpha1"]
+== StorageVersionMigrationList [migration.k8s.io/v1alpha1]
+
+
+Description::
++
+--
+StorageVersionMigrationList is a list of StorageVersionMigration
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/storageversionmigration-migration-k8s-io-v1alpha1.adoc#storageversionmigration-migration-k8s-io-v1alpha1[`array (StorageVersionMigration migration.k8s.io/v1alpha1)`]
+| List of storageversionmigrations. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="subscriptionlist-operators-coreos-com-v1alpha1"]
+== SubscriptionList [operators.coreos.com/v1alpha1]
+
+
+Description::
++
+--
+SubscriptionList is a list of Subscription
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../operatorhub_apis/subscription-operators-coreos-com-v1alpha1.adoc#subscription-operators-coreos-com-v1alpha1[`array (Subscription operators.coreos.com/v1alpha1)`]
+| List of subscriptions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="sysctl-core-v1"]
+== Sysctl [core/v1]
+
+
+Description::
++
+--
+Sysctl defines a kernel parameter to be set
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `value`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of a property to set
+
+| `value`
+| `string`
+| Value of a property to set
+
+|===
+
+[id="taint-core-v1"]
+== Taint [core/v1]
+
+
+Description::
++
+--
+The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+  - `effect`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `effect`
+| `string`
+| Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+| `key`
+| `string`
+| Required. The taint key to be applied to a node.
+
+| `timeAdded`
+| xref:../objects/index.adoc#time-meta-v1[`Time meta/v1`]
+| TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+
+| `value`
+| `string`
+| The taint value corresponding to the taint key.
+
+|===
+
+[id="tcpsocketaction-core-v1"]
+== TCPSocketAction [core/v1]
+
+
+Description::
++
+--
+TCPSocketAction describes an action based on opening a socket
+--
+
+Type::
+  `object`
+
+Required::
+  - `port`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `host`
+| `string`
+| Optional: Host name to connect to, defaults to the pod IP.
+
+| `port`
+| xref:../objects/index.adoc#intorstring-util-none[`IntOrString util/none`]
+| Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+
+|===
+
+[id="templateinstancelist-template-openshift-io-v1"]
+== TemplateInstanceList [template.openshift.io/v1]
+
+
+Description::
++
+--
+TemplateInstanceList is a list of TemplateInstance objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../template_apis/templateinstance-template-openshift-io-v1.adoc#templateinstance-template-openshift-io-v1[`array (TemplateInstance template.openshift.io/v1)`]
+| items is a list of Templateinstances
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="thanosrulerlist-monitoring-coreos-com-v1"]
+== ThanosRulerList [monitoring.coreos.com/v1]
+
+
+Description::
++
+--
+ThanosRulerList is a list of ThanosRuler
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../monitoring_apis/thanosruler-monitoring-coreos-com-v1.adoc#thanosruler-monitoring-coreos-com-v1[`array (ThanosRuler monitoring.coreos.com/v1)`]
+| List of thanosrulers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="time-meta-v1"]
+== Time [meta/v1]
+
+
+Description::
++
+--
+Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+--
+
+Type::
+  `string`
+
+
+
+[id="tokenrequest-authentication-k8s-io-v1"]
+== TokenRequest [authentication.k8s.io/v1]
+
+
+Description::
++
+--
+TokenRequest requests a token for a given service account.
+--
+
+Type::
+  `object`
+
+Required::
+  - `spec`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#objectmeta-meta-v1[`ObjectMeta meta/v1`]
+| Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+| `spec`
+| xref:../objects/index.adoc#tokenrequestspec-authentication-k8s-io-v1[`TokenRequestSpec authentication.k8s.io/v1`]
+| Spec holds information about the request being evaluated
+
+| `status`
+| xref:../objects/index.adoc#tokenrequeststatus-authentication-k8s-io-v1[`TokenRequestStatus authentication.k8s.io/v1`]
+| Status is filled in by the server and indicates whether the token can be authenticated.
+
+|===
+
+[id="toleration-core-v1"]
+== Toleration [core/v1]
+
+
+Description::
++
+--
+The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `effect`
+| `string`
+| Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+| `key`
+| `string`
+| Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+| `operator`
+| `string`
+| Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+| `tolerationSeconds`
+| `integer`
+| TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+| `value`
+| `string`
+| Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+|===
+
+[id="topologyselectorlabelrequirement-core-v1"]
+== TopologySelectorLabelRequirement [core/v1]
+
+
+Description::
++
+--
+A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.
+--
+
+Type::
+  `object`
+
+Required::
+  - `key`
+  - `values`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `key`
+| `string`
+| The label key that the selector applies to.
+
+| `values`
+| `array (string)`
+| An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
+
+|===
+
+[id="topologyselectorterm-core-v1"]
+== TopologySelectorTerm [core/v1]
+
+
+Description::
++
+--
+A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `matchLabelExpressions`
+| xref:../objects/index.adoc#topologyselectorlabelrequirement-core-v1[`array (TopologySelectorLabelRequirement core/v1)`]
+| A list of topology selector requirements by labels.
+
+|===
+
+[id="topologyspreadconstraint-core-v1"]
+== TopologySpreadConstraint [core/v1]
+
+
+Description::
++
+--
+TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+--
+
+Type::
+  `object`
+
+Required::
+  - `maxSkew`
+  - `topologyKey`
+  - `whenUnsatisfiable`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `labelSelector`
+| xref:../objects/index.adoc#labelselector-meta-v1[`LabelSelector meta/v1`]
+| LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+
+| `maxSkew`
+| `integer`
+| MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: \| zone1 \| zone2 \| zone3 \| \|   P   \|   P   \|       \| - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.
+
+| `topologyKey`
+| `string`
+| TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+
+| `whenUnsatisfiable`
+| `string`
+| WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+  but giving higher precedence to topologies that would help reduce the
+  skew.
+A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: \| zone1 \| zone2 \| zone3 \| \| P P P \|   P   \|   P   \| If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+|===
+
+[id="tunedlist-tuned-openshift-io-v1"]
+== TunedList [tuned.openshift.io/v1]
+
+
+Description::
++
+--
+TunedList is a list of Tuned
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../node_apis/tuned-tuned-openshift-io-v1.adoc#tuned-tuned-openshift-io-v1[`array (Tuned tuned.openshift.io/v1)`]
+| List of tuneds. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="typedlocalobjectreference-core-v1"]
+== TypedLocalObjectReference [core/v1]
+
+
+Description::
++
+--
+TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+--
+
+Type::
+  `object`
+
+Required::
+  - `kind`
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiGroup`
+| `string`
+| APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+
+| `kind`
+| `string`
+| Kind is the type of resource being referenced
+
+| `name`
+| `string`
+| Name is the name of resource being referenced
+
+|===
+
+[id="userlist-user-openshift-io-v1"]
+== UserList [user.openshift.io/v1]
+
+
+Description::
++
+--
+UserList is a collection of Users
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../user_and_group_apis/user-user-openshift-io-v1.adoc#user-user-openshift-io-v1[`array (User user.openshift.io/v1)`]
+| Items is the list of users
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="useroauthaccesstokenlist-oauth-openshift-io-v1"]
+== UserOAuthAccessTokenList [oauth.openshift.io/v1]
+
+
+Description::
++
+--
+UserOAuthAccessTokenList is a collection of access tokens issued on behalf of the requesting user
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../oauth_apis/useroauthaccesstoken-oauth-openshift-io-v1.adoc#useroauthaccesstoken-oauth-openshift-io-v1[`array (UserOAuthAccessToken oauth.openshift.io/v1)`]
+| 
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| 
+
+|===
+
+[id="validatingwebhookconfigurationlist-admissionregistration-k8s-io-v1"]
+== ValidatingWebhookConfigurationList [admissionregistration.k8s.io/v1]
+
+
+Description::
++
+--
+ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../extension_apis/validatingwebhookconfiguration-admissionregistration-k8s-io-v1.adoc#validatingwebhookconfiguration-admissionregistration-k8s-io-v1[`array (ValidatingWebhookConfiguration admissionregistration.k8s.io/v1)`]
+| List of ValidatingWebhookConfiguration.
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="volume-core-v1"]
+== Volume [core/v1]
+
+
+Description::
++
+--
+Volume represents a named volume in a pod that may be accessed by any container in the pod.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `awsElasticBlockStore`
+| xref:../objects/index.adoc#awselasticblockstorevolumesource-core-v1[`AWSElasticBlockStoreVolumeSource core/v1`]
+| AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| `azureDisk`
+| xref:../objects/index.adoc#azurediskvolumesource-core-v1[`AzureDiskVolumeSource core/v1`]
+| AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| `azureFile`
+| xref:../objects/index.adoc#azurefilevolumesource-core-v1[`AzureFileVolumeSource core/v1`]
+| AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| `cephfs`
+| xref:../objects/index.adoc#cephfsvolumesource-core-v1[`CephFSVolumeSource core/v1`]
+| CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+
+| `cinder`
+| xref:../objects/index.adoc#cindervolumesource-core-v1[`CinderVolumeSource core/v1`]
+| Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| `configMap`
+| xref:../objects/index.adoc#configmapvolumesource-core-v1[`ConfigMapVolumeSource core/v1`]
+| ConfigMap represents a configMap that should populate this volume
+
+| `csi`
+| xref:../objects/index.adoc#csivolumesource-core-v1[`CSIVolumeSource core/v1`]
+| CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+
+| `downwardAPI`
+| xref:../objects/index.adoc#downwardapivolumesource-core-v1[`DownwardAPIVolumeSource core/v1`]
+| DownwardAPI represents downward API about the pod that should populate this volume
+
+| `emptyDir`
+| xref:../objects/index.adoc#emptydirvolumesource-core-v1[`EmptyDirVolumeSource core/v1`]
+| EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| `ephemeral`
+| xref:../objects/index.adoc#ephemeralvolumesource-core-v1[`EphemeralVolumeSource core/v1`]
+| Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+   tracking are needed,
+c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+   information on the connection between this volume type
+   and PersistentVolumeClaim).
+
+Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
+
+| `fc`
+| xref:../objects/index.adoc#fcvolumesource-core-v1[`FCVolumeSource core/v1`]
+| FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+
+| `flexVolume`
+| xref:../objects/index.adoc#flexvolumesource-core-v1[`FlexVolumeSource core/v1`]
+| FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| `flocker`
+| xref:../objects/index.adoc#flockervolumesource-core-v1[`FlockerVolumeSource core/v1`]
+| Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+
+| `gcePersistentDisk`
+| xref:../objects/index.adoc#gcepersistentdiskvolumesource-core-v1[`GCEPersistentDiskVolumeSource core/v1`]
+| GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| `gitRepo`
+| xref:../objects/index.adoc#gitrepovolumesource-core-v1[`GitRepoVolumeSource core/v1`]
+| GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+| `glusterfs`
+| xref:../objects/index.adoc#glusterfsvolumesource-core-v1[`GlusterfsVolumeSource core/v1`]
+| Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+
+| `hostPath`
+| xref:../objects/index.adoc#hostpathvolumesource-core-v1[`HostPathVolumeSource core/v1`]
+| HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| `iscsi`
+| xref:../objects/index.adoc#iscsivolumesource-core-v1[`ISCSIVolumeSource core/v1`]
+| ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
+
+| `name`
+| `string`
+| Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| `nfs`
+| xref:../objects/index.adoc#nfsvolumesource-core-v1[`NFSVolumeSource core/v1`]
+| NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| `persistentVolumeClaim`
+| xref:../objects/index.adoc#persistentvolumeclaimvolumesource-core-v1[`PersistentVolumeClaimVolumeSource core/v1`]
+| PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| `photonPersistentDisk`
+| xref:../objects/index.adoc#photonpersistentdiskvolumesource-core-v1[`PhotonPersistentDiskVolumeSource core/v1`]
+| PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+
+| `portworxVolume`
+| xref:../objects/index.adoc#portworxvolumesource-core-v1[`PortworxVolumeSource core/v1`]
+| PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+
+| `projected`
+| xref:../objects/index.adoc#projectedvolumesource-core-v1[`ProjectedVolumeSource core/v1`]
+| Items for all in one resources secrets, configmaps, and downward API
+
+| `quobyte`
+| xref:../objects/index.adoc#quobytevolumesource-core-v1[`QuobyteVolumeSource core/v1`]
+| Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+
+| `rbd`
+| xref:../objects/index.adoc#rbdvolumesource-core-v1[`RBDVolumeSource core/v1`]
+| RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+
+| `scaleIO`
+| xref:../objects/index.adoc#scaleiovolumesource-core-v1[`ScaleIOVolumeSource core/v1`]
+| ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+
+| `secret`
+| xref:../objects/index.adoc#secretvolumesource-core-v1[`SecretVolumeSource core/v1`]
+| Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+| `storageos`
+| xref:../objects/index.adoc#storageosvolumesource-core-v1[`StorageOSVolumeSource core/v1`]
+| StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+
+| `vsphereVolume`
+| xref:../objects/index.adoc#vspherevirtualdiskvolumesource-core-v1[`VsphereVirtualDiskVolumeSource core/v1`]
+| VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+
+|===
+
+[id="volumeattachmentlist-storage-k8s-io-v1"]
+== VolumeAttachmentList [storage.k8s.io/v1]
+
+
+Description::
++
+--
+VolumeAttachmentList is a collection of VolumeAttachment objects.
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/volumeattachment-storage-k8s-io-v1.adoc#volumeattachment-storage-k8s-io-v1[`array (VolumeAttachment storage.k8s.io/v1)`]
+| Items is the list of VolumeAttachments
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+|===
+
+[id="volumedevice-core-v1"]
+== VolumeDevice [core/v1]
+
+
+Description::
++
+--
+volumeDevice describes a mapping of a raw block device within a container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `devicePath`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `devicePath`
+| `string`
+| devicePath is the path inside of the container that the device will be mapped to.
+
+| `name`
+| `string`
+| name must match the name of a persistentVolumeClaim in the pod
+
+|===
+
+[id="volumemount-core-v1"]
+== VolumeMount [core/v1]
+
+
+Description::
++
+--
+VolumeMount describes a mounting of a Volume within a container.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+  - `mountPath`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `mountPath`
+| `string`
+| Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+| `mountPropagation`
+| `string`
+| mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+| `name`
+| `string`
+| This must match the Name of a Volume.
+
+| `readOnly`
+| `boolean`
+| Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+| `subPath`
+| `string`
+| Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+| `subPathExpr`
+| `string`
+| Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+|===
+
+[id="volumenodeaffinity-core-v1"]
+== VolumeNodeAffinity [core/v1]
+
+
+Description::
++
+--
+VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `required`
+| xref:../objects/index.adoc#nodeselector-core-v1[`NodeSelector core/v1`]
+| Required specifies hard node constraints that must be met.
+
+|===
+
+[id="volumeprojection-core-v1"]
+== VolumeProjection [core/v1]
+
+
+Description::
++
+--
+Projection that may be projected along with other supported volume types
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `configMap`
+| xref:../objects/index.adoc#configmapprojection-core-v1[`ConfigMapProjection core/v1`]
+| information about the configMap data to project
+
+| `downwardAPI`
+| xref:../objects/index.adoc#downwardapiprojection-core-v1[`DownwardAPIProjection core/v1`]
+| information about the downwardAPI data to project
+
+| `secret`
+| xref:../objects/index.adoc#secretprojection-core-v1[`SecretProjection core/v1`]
+| information about the secret data to project
+
+| `serviceAccountToken`
+| xref:../objects/index.adoc#serviceaccounttokenprojection-core-v1[`ServiceAccountTokenProjection core/v1`]
+| information about the serviceAccountToken data to project
+
+|===
+
+[id="volumesnapshotclasslist-snapshot-storage-k8s-io-v1"]
+== VolumeSnapshotClassList [snapshot.storage.k8s.io/v1]
+
+
+Description::
++
+--
+VolumeSnapshotClassList is a list of VolumeSnapshotClass
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/volumesnapshotclass-snapshot-storage-k8s-io-v1.adoc#volumesnapshotclass-snapshot-storage-k8s-io-v1[`array (VolumeSnapshotClass snapshot.storage.k8s.io/v1)`]
+| List of volumesnapshotclasses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="volumesnapshotcontentlist-snapshot-storage-k8s-io-v1"]
+== VolumeSnapshotContentList [snapshot.storage.k8s.io/v1]
+
+
+Description::
++
+--
+VolumeSnapshotContentList is a list of VolumeSnapshotContent
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/volumesnapshotcontent-snapshot-storage-k8s-io-v1.adoc#volumesnapshotcontent-snapshot-storage-k8s-io-v1[`array (VolumeSnapshotContent snapshot.storage.k8s.io/v1)`]
+| List of volumesnapshotcontents. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="volumesnapshotlist-snapshot-storage-k8s-io-v1"]
+== VolumeSnapshotList [snapshot.storage.k8s.io/v1]
+
+
+Description::
++
+--
+VolumeSnapshotList is a list of VolumeSnapshot
+--
+
+Type::
+  `object`
+
+Required::
+  - `items`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `apiVersion`
+| `string`
+| APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+| `items`
+| xref:../storage_apis/volumesnapshot-snapshot-storage-k8s-io-v1.adoc#volumesnapshot-snapshot-storage-k8s-io-v1[`array (VolumeSnapshot snapshot.storage.k8s.io/v1)`]
+| List of volumesnapshots. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+| `kind`
+| `string`
+| Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+| `metadata`
+| xref:../objects/index.adoc#listmeta-meta-v1[`ListMeta meta/v1`]
+| Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+|===
+
+[id="vspherevirtualdiskvolumesource-core-v1"]
+== VsphereVirtualDiskVolumeSource [core/v1]
+
+
+Description::
++
+--
+Represents a vSphere volume resource.
+--
+
+Type::
+  `object`
+
+Required::
+  - `volumePath`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `fsType`
+| `string`
+| Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| `storagePolicyID`
+| `string`
+| Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+| `storagePolicyName`
+| `string`
+| Storage Policy Based Management (SPBM) profile name.
+
+| `volumePath`
+| `string`
+| Path that identifies vSphere volume vmdk
+
+|===
+
+[id="weightedpodaffinityterm-core-v1"]
+== WeightedPodAffinityTerm [core/v1]
+
+
+Description::
++
+--
+The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+--
+
+Type::
+  `object`
+
+Required::
+  - `weight`
+  - `podAffinityTerm`
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `podAffinityTerm`
+| xref:../objects/index.adoc#podaffinityterm-core-v1[`PodAffinityTerm core/v1`]
+| Required. A pod affinity term, associated with the corresponding weight.
+
+| `weight`
+| `integer`
+| weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+|===
+
+[id="windowssecuritycontextoptions-core-v1"]
+== WindowsSecurityContextOptions [core/v1]
+
+
+Description::
++
+--
+WindowsSecurityContextOptions contain Windows-specific options and credentials.
+--
+
+Type::
+  `object`
+
+
+[discrete]
+=== Specification
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `gmsaCredentialSpec`
+| `string`
+| GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+
+| `gmsaCredentialSpecName`
+| `string`
+| GMSACredentialSpecName is the name of the GMSA credential spec to use.
+
+| `hostProcess`
+| `boolean`
+| HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+
+| `runAsUserName`
+| `string`
+| The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+|===
+

--- a/examples/demo-assembly.adoc
+++ b/examples/demo-assembly.adoc
@@ -39,3 +39,6 @@ include::adoc-includes/installation-configuration-parameters.adoc[leveloffset=+1
 
 //This one has a really short definition list in step 2.
 include::adoc-includes/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
+
+//This one is a generated page from our REST API guide.
+include::adoc-includes/index.adoc[leveloffset=+1]


### PR DESCRIPTION
@wesruv, we want to explicitly check that OCP's REST API content will be allowable.

Here's the Confluence page that talks about it: https://docs.engineering.redhat.com/display/CCS/Publishing+Embedded+API+Content 

This PR adds a sample REST API module, in case you need it.